### PR TITLE
enable extrapolation in spreaded curve if enabled in discount curve

### DIFF
--- a/QuantLib/ql/cashflows/cashflows.cpp
+++ b/QuantLib/ql/cashflows/cashflows.cpp
@@ -1175,6 +1175,9 @@ namespace QuantLib {
         ZeroSpreadedTermStructure spreadedCurve(discountCurveHandle,
                                                 zSpreadQuoteHandle,
                                                 comp, freq, dc);
+
+        spreadedCurve.enableExtrapolation(discountCurveHandle->allowsExtrapolation());
+
         return npv(leg, spreadedCurve,
                    includeSettlementDateFlows,
                    settlementDate, npvDate);


### PR DESCRIPTION
when computing CashFlows::npv with a zSpread the spreaded curve does not allow for extrapolation even if the discount curve does. I guess this is not the expected behaviour.
