### PR TITLE
added analytic implied bpvol

### DIFF
--- a/QuantLib/ql/pricingengines/blackformula.hpp
+++ b/QuantLib/ql/pricingengines/blackformula.hpp
@@ -7,6 +7,7 @@
  Copyright (C) 2006 StatPro Italia srl
  Copyright (C) 2007 Cristina Duminuco
  Copyright (C) 2007 Chiara Fornarola
+ Copyright (C) 2013 Gary Kennedy
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -201,6 +202,19 @@ namespace QuantLib {
                         Real forward,
                         Real stdDev,
                         Real discount = 1.0);
+    /*! Approximated Bachelier implied volatility
+
+        It is calculated using  the analytic implied volatility approximation
+        of J. Choi, K Kim and M. Kwak (2009), “Numerical Approximation of the
+        Implied Volatility Under Arithmetic Brownian Motion”,
+        Applied Math. Finance, 16(3), pp. 261-268.
+    */
+    Real bachelierBlackFormulaImpliedVol(Option::Type optionType,
+                                   Real strike,
+                                   Real forward,
+                                   Real tte,
+                                   Real bachelierPrice,
+                                   Real discount = 1.0);
 
 }
 

--- a/QuantLib/test-suite/Makefile.am
+++ b/QuantLib/test-suite/Makefile.am
@@ -11,6 +11,7 @@ QL_TESTS = \
 	batesmodel.hpp batesmodel.cpp \
 	bermudanswaption.hpp bermudanswaption.cpp \
 	blackdeltacalculator.hpp blackdeltacalculator.cpp \
+	blackformula.hpp blackformula.cpp \
 	bonds.hpp bonds.cpp \
 	brownianbridge.hpp brownianbridge.cpp \
 	calendars.hpp calendars.cpp \

--- a/QuantLib/test-suite/blackformula.cpp
+++ b/QuantLib/test-suite/blackformula.cpp
@@ -1,0 +1,64 @@
+
+/*
+ Copyright (C) 2013 Gary Kennedy
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+
+#include "blackformula.hpp"
+#include "utilities.hpp"
+#include <ql/pricingengines/blackformula.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+
+void BlackFormulaTest::testBachelierImpliedVol(){
+
+
+    BOOST_TEST_MESSAGE("Testing Bachelier implied vol...");
+
+    Real forward = 1.0;
+    Real bpvol = 0.01;
+    Real tte = 10.0;
+    Real stdDev = bpvol*std::sqrt(tte);
+    Option::Type optionType = Option::Call;
+    Real discount = 0.95;
+
+    Real d[] = {-3.0, -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0};
+    for(int i=0;i<LENGTH(d);++i){
+
+
+        Real strike = forward - d[i] * bpvol * std::sqrt(tte);
+
+        Real callPrem = bachelierBlackFormula(optionType, strike, forward, stdDev, discount);
+
+        Real impliedBpVol = bachelierBlackFormulaImpliedVol(optionType,strike, forward, tte, callPrem, discount);
+
+        if (std::fabs(bpvol-impliedBpVol)>1.0e-12){
+            BOOST_ERROR("Failed, expected " << bpvol << " realised " << impliedBpVol );
+        }
+    }
+    return;
+}
+
+test_suite* BlackFormulaTest::suite() {
+    test_suite* suite = BOOST_TEST_SUITE("Black formula tests");
+
+    suite->add(QUANTLIB_TEST_CASE(
+        &BlackFormulaTest::testBachelierImpliedVol));
+
+    return suite;
+}

--- a/QuantLib/test-suite/blackformula.hpp
+++ b/QuantLib/test-suite/blackformula.hpp
@@ -1,0 +1,32 @@
+
+/*
+ Copyright (C) 2003 Gary Kennedy
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_blackformula_hpp
+#define quantlib_test_blackformula_hpp
+
+#include <boost/test/unit_test.hpp>
+
+
+class BlackFormulaTest {
+  public:
+    static void testBachelierImpliedVol();
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+
+#endif

--- a/QuantLib/test-suite/quantlibtestsuite.cpp
+++ b/QuantLib/test-suite/quantlibtestsuite.cpp
@@ -52,6 +52,7 @@
 #include "batesmodel.hpp"
 #include "bermudanswaption.hpp"
 #include "blackdeltacalculator.hpp"
+#include "blackformula.hpp"
 #include "bonds.hpp"
 #include "brownianbridge.hpp"
 #include "calendars.hpp"
@@ -252,6 +253,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(QUANTLIB_TEST_CASE(startTimer));
     test->add(QUANTLIB_TEST_CASE(configure));
 
+
     test->add(AmericanOptionTest::suite());
     test->add(ArrayTest::suite());
     test->add(AsianOptionTest::suite());
@@ -261,6 +263,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(BasketOptionTest::suite());
     test->add(BatesModelTest::suite());
     test->add(BermudanSwaptionTest::suite());
+    test->add(BlackFormulaTest::suite());
     test->add(BondTest::suite());
     test->add(BrownianBridgeTest::suite());
     test->add(CalendarTest::suite());


### PR DESCRIPTION
Added the analytic implied volatility approximation of J. Choi, K Kim and M. Kwak (2009), “Numerical Approximation of the Implied Volatility Under Arithmetic Brownian Motion”, Applied Math. Finance, 16(3), pp. 261-268.

Given the premium of an option, it provides an analytic approximation of implied volatility of the bachelier formula. In interest rate the volatility is referred to as bpvol.
