### PR TITLE
disable non working test case

### DIFF
--- a/QuantLib/test-suite/swapforwardmappings.cpp
+++ b/QuantLib/test-suite/swapforwardmappings.cpp
@@ -460,10 +460,10 @@ test_suite* SwapForwardMappingsTest::suite() {
 
     suite->add(QUANTLIB_TEST_CASE(
         &SwapForwardMappingsTest::testForwardSwapJacobians));
-#if !defined(QL_NO_UBLAS_SUPPORT)
-    suite->add(QUANTLIB_TEST_CASE(
-        &SwapForwardMappingsTest::testForwardCoterminalMappings));
-#endif
+// #if !defined(QL_NO_UBLAS_SUPPORT)
+//     suite->add(QUANTLIB_TEST_CASE(
+//         &SwapForwardMappingsTest::testForwardCoterminalMappings));
+// #endif
     return suite;
 }
 


### PR DESCRIPTION
Hi Luigi, I noticed that the test case I reactivated lately does not work actually. You can only see that something goes
wrong when messages are enabled because no errors are thrown. Anyway the results do not look ok. I will have a
closer look later on. I suggest to exclude the case completely from the suite until it is fixed. Regards, Peter
