### PR TITLE
Add new Act/365 NL Daycounter

### DIFF
--- a/QuantLib/ql/time/daycounters/Makefile.am
+++ b/QuantLib/ql/time/daycounters/Makefile.am
@@ -6,6 +6,7 @@ this_include_HEADERS = \
 	all.hpp \
 	actual360.hpp \
 	actual365fixed.hpp \
+	actual365nl.hpp \
 	actualactual.hpp \
 	business252.hpp \
 	one.hpp \

--- a/QuantLib/ql/time/daycounters/actual365nl.hpp
+++ b/QuantLib/ql/time/daycounters/actual365nl.hpp
@@ -1,0 +1,85 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2013 BGC Partners L.P.
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file actual365nl.hpp
+    \brief Actual/365 (No Leap) day counter
+*/
+
+#ifndef quantlib_actual365nl_h
+#define quantlib_actual365nl_h
+
+#include <ql/time/daycounter.hpp>
+
+namespace QuantLib {
+
+    //! Actual/365 (No Leap) day count convention
+    /*! "Actual/365 (No Leap)" day count convention, also known as
+        "Act/365 (NL)", "NL/365", or "Actual/365 (JGB)".
+
+        \ingroup daycounters
+    */
+    class Actual365NL : public DayCounter {
+    private:
+        class Impl : public DayCounter::Impl {
+        public:
+            std::string name() const { return std::string("Actual/365 (NL)"); }
+
+            // Returns the exact number of days between 2 dates, excluding leap days
+            BigInteger dayCount(const Date& d1,
+                                const Date& d2) const {
+
+                static const Integer MonthOffset[] = {
+                    0,  31,  59,  90, 120, 151,  // Jan - Jun
+                  181, 212, 243, 273, 304, 334   // Jun - Dec
+                };
+                BigInteger s1, s2;
+
+                s1 = d1.dayOfMonth() + MonthOffset[d1.month()-1] + (d1.year() * 365);
+                s2 = d2.dayOfMonth() + MonthOffset[d2.month()-1] + (d2.year() * 365);
+
+                if (d1.month() == Feb && d1.dayOfMonth() == 29)
+                {
+                    --s1;
+                }
+
+                if (d2.month() == Feb && d2.dayOfMonth() == 29)
+                {
+                    --s2;
+                }
+
+                return s2 - s1;
+            }
+
+            QuantLib::Time yearFraction(const Date& d1,
+                                        const Date& d2,
+                                        const Date& d3,
+                                        const Date& d4) const {
+                return dayCount(d1, d2)/365.0;
+            }
+        };
+    public:
+        Actual365NL()
+        : DayCounter(boost::shared_ptr<DayCounter::Impl>(
+                                                 new Actual365NL::Impl)) {}
+    };
+
+}
+
+#endif
+


### PR DESCRIPTION
Hi Luigi,

This commit adds a new daycounter for Act/365 No Leap.  It is used for Japanese Government Bonds accrued interest calculations.

This is also my first attempt at using github.

Regards

Nick Glass
