### PR TITLE
fixed compile issue in normaldistribution.hpp

### DIFF
--- a/QuantLib/ql/math/distributions/normaldistribution.hpp
+++ b/QuantLib/ql/math/distributions/normaldistribution.hpp
@@ -127,9 +127,9 @@ namespace QuantLib {
             // than 1.15e-9.  One iteration of Halley's rational method (third
             // order) gives full machine precision.
             // #define REFINE_TO_FULL_MACHINE_PRECISION_USING_HALLEYS_METHOD
-            #ifdef  REFINE_TO_FULL_MACHINE_PRECISION_USING_HALLEYS_METHOD
+            #ifdef REFINE_TO_FULL_MACHINE_PRECISION_USING_HALLEYS_METHOD
             // error (f_(z) - x) divided by the cumulative's derivative
-            r = (f_(z) - x) * M_SQRT2 * M_SQRTPI * exp(0.5 * z*z);
+            const Real r = (f_(z) - x) * M_SQRT2 * M_SQRTPI * exp(0.5 * z*z);
             //  Halley's method
             z -= r/(1+0.5*z*r);
             #endif

--- a/QuantLib/ql/termstructures/volatility/equityfx/blackvariancesurface.cpp
+++ b/QuantLib/ql/termstructures/volatility/equityfx/blackvariancesurface.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
                    "mismatch between money-strike vector and vol matrix rows");
 
         QL_REQUIRE(dates[0]>=referenceDate,
-                   "cannot have dates[0] <= referenceDate");
+                   "cannot have dates[0] < referenceDate");
 
         Size j, i;
         times_ = std::vector<Time>(dates.size()+1);


### PR DESCRIPTION
fixed compile issue when using Halley's Method to refine the inverse of the cumulative normal distribution.
