### PR TITLE
add -fPIC to java compile

### DIFF
--- a/QuantLib-SWIG/Java/Makefile.am
+++ b/QuantLib-SWIG/Java/Makefile.am
@@ -5,6 +5,8 @@ BUILT_SOURCES = quantlib_wrap.cpp quantlib_wrap.h
 
 EXAMPLES = DiscreteHedging EquityOptions FRA UnaryFunctions
 
+AM_CXXFLAGS= -fPIC
+
 if HAVE_JAVA
 if BUILD_JAVA
 


### PR DESCRIPTION
This is necessary to get Java swig to compile.
