### PR TITLE
Implement ex-coupon date for fixed rate bonds

### DIFF
--- a/QuantLib/ql/cashflow.cpp
+++ b/QuantLib/ql/cashflow.cpp
@@ -48,6 +48,18 @@ namespace QuantLib {
         return Event::hasOccurred(refDate, includeRefDate);
     }
 
+    bool CashFlow::tradingExCoupon(const Date& refDate) const {
+
+        Date ecd = exCouponDate();
+        if (ecd == Date())
+            return false;
+
+        Date ref =
+            refDate != Date() ? refDate : Settings::instance().evaluationDate();
+
+        return ecd <= ref;
+    }
+
     void CashFlow::accept(AcyclicVisitor& v) {
         Visitor<CashFlow>* v1 = dynamic_cast<Visitor<CashFlow>*>(&v);
         if (v1 != 0)

--- a/QuantLib/ql/cashflow.hpp
+++ b/QuantLib/ql/cashflow.hpp
@@ -57,6 +57,11 @@ namespace QuantLib {
                   amount paid at the cash flow date.
         */
         virtual Real amount() const = 0;
+        //! returns the date that the cash flow trades exCoupon
+        virtual Date exCouponDate() const {return Date();};
+        //! returns true if the cashflow is trading ex-coupon on the refDate
+        bool tradingExCoupon(const Date& refDate = Date()) const;
+
         //@}
         //! \name Visitability
         //@{

--- a/QuantLib/ql/cashflows/cashflows.cpp
+++ b/QuantLib/ql/cashflows/cashflows.cpp
@@ -458,7 +458,8 @@ namespace QuantLib {
         Real totalNPV = 0.0;
         for (Size i=0; i<leg.size(); ++i) {
             if (!leg[i]->hasOccurred(settlementDate,
-                                     includeSettlementDateFlows))
+                                     includeSettlementDateFlows) &&
+                !leg[i]->tradingExCoupon(settlementDate))
                 totalNPV += leg[i]->amount() *
                             discountCurve.discount(leg[i]->date());
         }
@@ -483,7 +484,8 @@ namespace QuantLib {
         BPSCalculator calc(discountCurve);
         for (Size i=0; i<leg.size(); ++i) {
             if (!leg[i]->hasOccurred(settlementDate,
-                                     includeSettlementDateFlows))
+                                     includeSettlementDateFlows) &&
+                !leg[i]->tradingExCoupon(settlementDate))
                 leg[i]->accept(calc);
         }
         return basisPoint_*calc.bps()/discountCurve.discount(npvDate);
@@ -507,7 +509,8 @@ namespace QuantLib {
         for (Size i=0; i<leg.size(); ++i) {
             CashFlow& cf = *leg[i];
             if (!cf.hasOccurred(settlementDate,
-                                includeSettlementDateFlows)) {
+                                includeSettlementDateFlows) &&
+                !cf.tradingExCoupon(settlementDate)) {
                 npv += cf.amount() *
                        discountCurve.discount(cf.date());
                 cf.accept(calc);
@@ -536,7 +539,8 @@ namespace QuantLib {
         for (Size i=0; i<leg.size(); ++i) {
             CashFlow& cf = *leg[i];
             if (!cf.hasOccurred(settlementDate,
-                                includeSettlementDateFlows)) {
+                                includeSettlementDateFlows) &&
+                !cf.tradingExCoupon(settlementDate)) {
                 npv += cf.amount() *
                        discountCurve.discount(cf.date());
                 cf.accept(calc);
@@ -599,6 +603,10 @@ namespace QuantLib {
                     continue;
 
                 Real c = leg[i]->amount();
+                if (leg[i]->tradingExCoupon(settlementDate)) {
+                    c = 0.0;
+                }
+
                 Date couponDate = leg[i]->date();
                 shared_ptr<Coupon> coupon =
                     boost::dynamic_pointer_cast<Coupon>(leg[i]);
@@ -658,6 +666,10 @@ namespace QuantLib {
                     continue;
 
                 Real c = leg[i]->amount();
+                if (leg[i]->tradingExCoupon(settlementDate)) {
+                    c = 0.0;
+                }
+
                 Date couponDate = leg[i]->date();
                 shared_ptr<Coupon> coupon =
                     boost::dynamic_pointer_cast<Coupon>(leg[i]);
@@ -771,7 +783,8 @@ namespace QuantLib {
                         signChanges = 0;
                 for (Size i = 0; i < leg_.size(); ++i) {
                     if (!leg_[i]->hasOccurred(settlementDate_,
-                                              includeSettlementDateFlows_)) {
+                                              includeSettlementDateFlows_) &&
+                        !leg_[i]->tradingExCoupon(settlementDate_)) {
                         Integer thisSign = sign(leg_[i]->amount());
                         if (lastSign * thisSign < 0) // sign change
                             signChanges++;
@@ -843,6 +856,10 @@ namespace QuantLib {
 
             Date couponDate = leg[i]->date();
             Real amount = leg[i]->amount();
+            if (leg[i]->tradingExCoupon(settlementDate)) {
+                amount = 0.0;
+            }
+
             shared_ptr<Coupon> coupon =
                 boost::dynamic_pointer_cast<Coupon>(leg[i]);
             if (coupon) {
@@ -1017,6 +1034,10 @@ namespace QuantLib {
                 continue;
             
             Real c = leg[i]->amount();
+            if (leg[i]->tradingExCoupon(settlementDate)) {
+                c = 0.0;
+            }
+
             Date couponDate = leg[i]->date();
             shared_ptr<Coupon> coupon =
                 boost::dynamic_pointer_cast<Coupon>(leg[i]);

--- a/QuantLib/ql/cashflows/coupon.cpp
+++ b/QuantLib/ql/cashflows/coupon.cpp
@@ -29,10 +29,12 @@ namespace QuantLib {
                    const Date& accrualStartDate,
                    const Date& accrualEndDate,
                    const Date& refPeriodStart,
-                   const Date& refPeriodEnd)
+                   const Date& refPeriodEnd,
+                   const Date& exCouponDate)
     : paymentDate_(paymentDate), nominal_(nominal), 
       accrualStartDate_(accrualStartDate), accrualEndDate_(accrualEndDate),
-      refPeriodStart_(refPeriodStart), refPeriodEnd_(refPeriodEnd) {
+      refPeriodStart_(refPeriodStart), refPeriodEnd_(refPeriodEnd),
+      exCouponDate_(exCouponDate) {
         if (refPeriodStart_ == Date())
             refPeriodStart_ = accrualStartDate_;
         if (refPeriodEnd_ == Date())

--- a/QuantLib/ql/cashflows/coupon.hpp
+++ b/QuantLib/ql/cashflows/coupon.hpp
@@ -46,10 +46,15 @@ namespace QuantLib {
                const Date& accrualStartDate,
                const Date& accrualEndDate,
                const Date& refPeriodStart = Date(),
-               const Date& refPeriodEnd = Date());
+               const Date& refPeriodEnd = Date(),
+               const Date& exCouponDate = Date());
         //! \name Event interface
         //@{
         Date date() const { return paymentDate_; }
+        //@}
+        //! \name CashFlow interface
+        //@{
+        Date exCouponDate() const { return exCouponDate_; }
         //@}
         //! \name Inspectors
         //@{
@@ -82,7 +87,7 @@ namespace QuantLib {
         virtual void accept(AcyclicVisitor&);
         //@}
       protected:
-        Date paymentDate_;
+        Date paymentDate_, exCouponDate_;
         Real nominal_;
         Date accrualStartDate_,accrualEndDate_, refPeriodStart_,refPeriodEnd_;
     };

--- a/QuantLib/ql/cashflows/fixedratecoupon.hpp
+++ b/QuantLib/ql/cashflows/fixedratecoupon.hpp
@@ -47,14 +47,16 @@ namespace QuantLib {
                         const Date& accrualStartDate,
                         const Date& accrualEndDate,
                         const Date& refPeriodStart = Date(),
-                        const Date& refPeriodEnd = Date());
+                        const Date& refPeriodEnd = Date(),
+                        const Date& exCouponDate = Date());
         FixedRateCoupon(const Date& paymentDate,
                         Real nominal,
                         const InterestRate& interestRate,
                         const Date& accrualStartDate,
                         const Date& accrualEndDate,
                         const Date& refPeriodStart = Date(),
-                        const Date& refPeriodEnd = Date());
+                        const Date& refPeriodEnd = Date(),
+                        const Date& exCouponDate = Date());
         //@}
         //! \name CashFlow interface
         //@{
@@ -96,6 +98,10 @@ namespace QuantLib {
         FixedRateLeg& withPaymentAdjustment(BusinessDayConvention);
         FixedRateLeg& withFirstPeriodDayCounter(const DayCounter&);
         FixedRateLeg& withPaymentCalendar(const Calendar&);
+        FixedRateLeg& withExCouponPeriod(const Period&,
+                                         const Calendar&,
+                                         BusinessDayConvention,
+                                         bool endOfMonth);
         operator Leg() const;
       private:
         Schedule schedule_;
@@ -104,6 +110,10 @@ namespace QuantLib {
         std::vector<InterestRate> couponRates_;
         DayCounter firstPeriodDC_;
         BusinessDayConvention paymentAdjustment_;
+        Period exCouponPeriod_;
+        Calendar exCouponCalendar_;
+        BusinessDayConvention exCouponAdjustment_;
+        bool exCouponEndOfMonth_;
     };
 
     inline void FixedRateCoupon::accept(AcyclicVisitor& v) {

--- a/QuantLib/ql/instruments/bonds/fixedratebond.cpp
+++ b/QuantLib/ql/instruments/bonds/fixedratebond.cpp
@@ -36,7 +36,11 @@ namespace QuantLib {
                                  BusinessDayConvention paymentConvention,
                                  Real redemption,
                                  const Date& issueDate,
-                                 const Calendar& paymentCalendar)
+                                 const Calendar& paymentCalendar,
+                                 const Period& exCouponPeriod,
+                                 const Calendar& exCouponCalendar,
+                                 const BusinessDayConvention exCouponConvention,
+                                 bool exCouponEndOfMonth)
      : Bond(settlementDays,
             paymentCalendar==Calendar() ? schedule.calendar() : paymentCalendar,
             issueDate),
@@ -49,7 +53,11 @@ namespace QuantLib {
             .withNotionals(faceAmount)
             .withCouponRates(coupons, accrualDayCounter)
             .withPaymentCalendar(calendar_)
-            .withPaymentAdjustment(paymentConvention);
+            .withPaymentAdjustment(paymentConvention)
+            .withExCouponPeriod(exCouponPeriod,
+                                exCouponCalendar,
+                                exCouponConvention,
+                                exCouponEndOfMonth);
 
         addRedemptionsToCashflows(std::vector<Real>(1, redemption));
 
@@ -72,7 +80,11 @@ namespace QuantLib {
                                  const Date& stubDate,
                                  DateGeneration::Rule rule,
                                  bool endOfMonth,
-                                 const Calendar& paymentCalendar)
+                                 const Calendar& paymentCalendar,
+                                 const Period& exCouponPeriod,
+                                 const Calendar& exCouponCalendar,
+                                 const BusinessDayConvention exCouponConvention,
+                                 bool exCouponEndOfMonth)
      : Bond(settlementDays,
             paymentCalendar==Calendar() ? calendar : paymentCalendar,
             issueDate),
@@ -109,7 +121,11 @@ namespace QuantLib {
             .withNotionals(faceAmount)
             .withCouponRates(coupons, accrualDayCounter)
             .withPaymentCalendar(calendar_)
-            .withPaymentAdjustment(paymentConvention);
+            .withPaymentAdjustment(paymentConvention)
+            .withExCouponPeriod(exCouponPeriod,
+                                exCouponCalendar,
+                                exCouponConvention,
+                                exCouponEndOfMonth);
 
         addRedemptionsToCashflows(std::vector<Real>(1, redemption));
 
@@ -124,7 +140,11 @@ namespace QuantLib {
                                  BusinessDayConvention paymentConvention,
                                  Real redemption,
                                  const Date& issueDate,
-                                 const Calendar& paymentCalendar)
+                                 const Calendar& paymentCalendar,
+                                 const Period& exCouponPeriod,
+                                 const Calendar& exCouponCalendar,
+                                 const BusinessDayConvention exCouponConvention,
+                                 bool exCouponEndOfMonth)
      : Bond(settlementDays,
             paymentCalendar==Calendar() ? schedule.calendar() : paymentCalendar,
             issueDate),
@@ -137,7 +157,11 @@ namespace QuantLib {
             .withNotionals(faceAmount)
             .withCouponRates(coupons)
             .withPaymentCalendar(calendar_)
-            .withPaymentAdjustment(paymentConvention);
+            .withPaymentAdjustment(paymentConvention)
+            .withExCouponPeriod(exCouponPeriod,
+                                exCouponCalendar,
+                                exCouponConvention,
+                                exCouponEndOfMonth);
 
         addRedemptionsToCashflows(std::vector<Real>(1, redemption));
 

--- a/QuantLib/ql/instruments/bonds/fixedratebond.hpp
+++ b/QuantLib/ql/instruments/bonds/fixedratebond.hpp
@@ -54,7 +54,11 @@ namespace QuantLib {
                       BusinessDayConvention paymentConvention = Following,
                       Real redemption = 100.0,
                       const Date& issueDate = Date(),
-                      const Calendar& paymentCalendar = Calendar());
+                      const Calendar& paymentCalendar = Calendar(),
+                      const Period& exCouponPeriod = Period(),
+                      const Calendar& exCouponCalendar = Calendar(),
+                      const BusinessDayConvention exCouponConvention = Unadjusted,
+                      bool exCouponEndOfMonth = false);
         /*! simple annual compounding coupon rates
             with internal schedule calculation */
         FixedRateBond(Natural settlementDays,
@@ -72,7 +76,11 @@ namespace QuantLib {
                       const Date& stubDate = Date(),
                       DateGeneration::Rule rule = DateGeneration::Backward,
                       bool endOfMonth = false,
-                      const Calendar& paymentCalendar = Calendar());
+                      const Calendar& paymentCalendar = Calendar(),
+                      const Period& exCouponPeriod = Period(),
+                      const Calendar& exCouponCalendar = Calendar(),
+                      const BusinessDayConvention exCouponConvention = Unadjusted,
+                      bool exCouponEndOfMonth = false);
         //! generic compounding and frequency InterestRate coupons 
         FixedRateBond(Natural settlementDays,
                       Real faceAmount,
@@ -81,7 +89,11 @@ namespace QuantLib {
                       BusinessDayConvention paymentConvention = Following,
                       Real redemption = 100.0,
                       const Date& issueDate = Date(),
-                      const Calendar& paymentCalendar = Calendar());
+                      const Calendar& paymentCalendar = Calendar(),
+                      const Period& exCouponPeriod = Period(),
+                      const Calendar& exCouponCalendar = Calendar(),
+                      const BusinessDayConvention exCouponConvention = Unadjusted,
+                      bool exCouponEndOfMonth = false);
         Frequency frequency() const { return frequency_; }
         const DayCounter& dayCounter() const { return dayCounter_; }
       protected:


### PR DESCRIPTION
Hi Luigi,

This commit adds support for ex-coupon dates to fixed rate bonds and updates the cashflow calculations to take account of this date.  The results have been verified against Bloomberg for UK Gilts and Australian Government Bonds.

Test code following shortly.

Thanks

Nick
