### PR TITLE
fix annuity computation

### DIFF
--- a/QuantLib/ql/cashflows/conundrumpricer.cpp
+++ b/QuantLib/ql/cashflows/conundrumpricer.cpp
@@ -104,7 +104,7 @@ namespace QuantLib {
             swapRateValue_ = swap->fairRate();
 
             static const Spread bp = 1.0e-4;
-            annuity_ = (swap->floatingLegBPS()/bp);
+            annuity_ = std::fabs(swap->fixedLegBPS()/bp);
 
             Size q = swapIndex->fixedLegTenor().frequency();
             const Schedule& schedule = swap->fixedSchedule();

--- a/QuantLib/test-suite/cms.cpp
+++ b/QuantLib/test-suite/cms.cpp
@@ -370,7 +370,7 @@ void CmsTest::testCmsSwap() {
             Real priceAn = cms[sl]->NPV();
 
             Real difference =  std::fabs(priceNum-priceAn);
-            Real tol = 1.0e-4;
+            Real tol = 2.0e-4;
             if (difference > tol)
                 BOOST_FAIL("\nLength in Years:  " << swapLengths[sl] <<
                            //"\nfloor:            " << io::rate(infiniteFloor) <<


### PR DESCRIPTION
This fixes the annuity computation in the Hagan cms coupon pricers. With that we have to increase the tolerance in one of the test cases which is also part of this commit.
