### PR TITLE
fix interpolation of option dates for floating SwVolTS

### DIFF
--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvoldiscrete.cpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvoldiscrete.cpp
@@ -187,6 +187,7 @@ namespace QuantLib {
                 evaluationDate_ = d;
                 initializeOptionDatesAndTimes();
                 initializeSwapLengths();
+                optionInterpolator_.update();
             }
         }
         TermStructure::update();


### PR DESCRIPTION
LinearInterpolation requires an explicit call of update() after change of x or y values, otherwise it is in an inconsistent state
