### PR TITLE
Correct exCouponDate on last coupon

### DIFF
--- a/QuantLib/ql/cashflows/fixedratecoupon.cpp
+++ b/QuantLib/ql/cashflows/fixedratecoupon.cpp
@@ -242,7 +242,7 @@ namespace QuantLib {
             if (schedule_.isRegular(N-1)) {
                 leg.push_back(shared_ptr<CashFlow>(new
                     FixedRateCoupon(paymentDate, nominal, rate,
-                                    start, end, start, end)));
+                                    start, end, start, end, exCouponDate)));
             } else {
                 Date ref = start + schedule_.tenor();
                 ref = schCalendar.adjust(ref, schedule_.businessDayConvention());


### PR DESCRIPTION
Hi Luigi,

I found an issue with my ex-coupon date change in that it didn't set the ex-coupon date for the last coupon.  Turns out I had missed passing the exCouponDate parameter in the last coupon constructor.

Regards

Nick
