### PR TITLE
Optimize OIS Curve Bootstrapping

### DIFF
--- a/QuantLib/ql/cashflows/overnightindexedcoupon.cpp
+++ b/QuantLib/ql/cashflows/overnightindexedcoupon.cpp
@@ -131,13 +131,13 @@ namespace QuantLib {
                          dayCounter, false) {
 
         // value dates
-        Date evalDate = Settings::instance().evaluationDate();
-        Date tmpEndDate =
-            telescopicValueDates
-                ? overnightIndex->fixingCalendar().adjust(
-                      std::min(std::max(evalDate, startDate) + 7, endDate),
-                      Following)
-                : endDate;
+        Date tmpEndDate = endDate;
+        if (telescopicValueDates) {
+            Date evalDate = Settings::instance().evaluationDate();
+            tmpEndDate = overnightIndex->fixingCalendar().advance(
+                std::max(startDate, evalDate), 7, Days, Following);
+            tmpEndDate = std::min(tmpEndDate, endDate);
+        }
         Schedule sch =
             MakeSchedule()
                 .from(startDate)
@@ -149,13 +149,15 @@ namespace QuantLib {
                 .backwards();
         valueDates_ = sch.dates();
 
-        if(telescopicValueDates) {
+        if (telescopicValueDates) {
             // ensure two dates at the tail
-            Date tmp = overnightIndex->fixingCalendar().advance(endDate, -1, Days, Preceding);
-            if(tmp != valueDates_.back())
+            Date tmp = overnightIndex->fixingCalendar().advance(
+                endDate, -1, Days, Preceding);
+            if (tmp != valueDates_.back())
                 valueDates_.push_back(tmp);
-            tmp = overnightIndex->fixingCalendar().adjust(endDate,overnightIndex->businessDayConvention());
-            if(tmp != valueDates_.back())
+            tmp = overnightIndex->fixingCalendar().adjust(
+                endDate, overnightIndex->businessDayConvention());
+            if (tmp != valueDates_.back())
                 valueDates_.push_back(tmp);
         }
 

--- a/QuantLib/ql/cashflows/overnightindexedcoupon.cpp
+++ b/QuantLib/ql/cashflows/overnightindexedcoupon.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2009 Roland Lichters
  Copyright (C) 2009 Ferdinando Ametrano
+ Copyright (C) 2014 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/QuantLib/ql/cashflows/overnightindexedcoupon.cpp
+++ b/QuantLib/ql/cashflows/overnightindexedcoupon.cpp
@@ -121,7 +121,8 @@ namespace QuantLib {
                     Spread spread,
                     const Date& refPeriodStart,
                     const Date& refPeriodEnd,
-                    const DayCounter& dayCounter)
+                    const DayCounter& dayCounter,
+                    const bool telescopicValueDates)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
                          overnightIndex->fixingDays(), overnightIndex,
                          gearing, spread,
@@ -129,14 +130,25 @@ namespace QuantLib {
                          dayCounter, false) {
 
         // value dates
-        Schedule sch = MakeSchedule()
-                    .from(startDate)
-                    .to(endDate)
-                    .withTenor(1*Days)
-                    .withCalendar(overnightIndex->fixingCalendar())
-                    .withConvention(overnightIndex->businessDayConvention())
-                    .backwards();
+        Date evalDate = Settings::instance().evaluationDate();
+        Date tmpEndDate = telescopicValueDates ? std::min( std::max(evalDate, startDate) + 7 , endDate) : endDate;
+        Schedule sch =
+            MakeSchedule()
+                .from(startDate)
+                // .to(endDate)
+                .to(tmpEndDate)
+                .withTenor(1 * Days)
+                .withCalendar(overnightIndex->fixingCalendar())
+                .withConvention(overnightIndex->businessDayConvention())
+                .backwards();
         valueDates_ = sch.dates();
+
+        if(telescopicValueDates) {
+            Date tmp = overnightIndex->fixingCalendar().adjust(endDate,overnightIndex->businessDayConvention());
+            if(tmp != valueDates_.back())
+                valueDates_.push_back(tmp);
+        }
+
         QL_ENSURE(valueDates_.size()>=2, "degenerate schedule");
 
         // fixing dates
@@ -177,9 +189,10 @@ namespace QuantLib {
         }
     }
 
-    OvernightLeg::OvernightLeg(const Schedule& schedule,
-                               const shared_ptr<OvernightIndex>& i)
-    : schedule_(schedule), overnightIndex_(i), paymentAdjustment_(Following) {}
+    OvernightLeg::OvernightLeg(const Schedule &schedule,
+                               const shared_ptr<OvernightIndex> &i)
+        : schedule_(schedule), overnightIndex_(i),
+          paymentAdjustment_(Following), telescopicValueDates_(false) {}
 
     OvernightLeg& OvernightLeg::withNotionals(Real notional) {
         notionals_ = vector<Real>(1, notional);
@@ -222,6 +235,11 @@ namespace QuantLib {
         return *this;
     }
 
+    OvernightLeg& OvernightLeg::withTelescopicValueDates(const bool telescopicValueDates) {
+        telescopicValueDates_ = telescopicValueDates;
+        return *this;
+    }
+
     OvernightLeg::operator Leg() const {
 
         QL_REQUIRE(!notionals_.empty(), "no notional given");
@@ -255,7 +273,8 @@ namespace QuantLib {
                                        detail::get(gearings_, i, 1.0),
                                        detail::get(spreads_, i, 0.0),
                                        refStart, refEnd,
-                                       paymentDayCounter_)));
+                                       paymentDayCounter_,
+                                       telescopicValueDates_)));
         }
         return cashflows;
     }

--- a/QuantLib/ql/cashflows/overnightindexedcoupon.hpp
+++ b/QuantLib/ql/cashflows/overnightindexedcoupon.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2009 Roland Lichters
  Copyright (C) 2009 Ferdinando Ametrano
+ Copyright (C) 2014 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -32,7 +33,11 @@
 namespace QuantLib {
 
     //! overnight coupon
-    /*! %Coupon paying the compounded interest due to daily overnight fixings. */
+    /*! %Coupon paying the compounded interest due to daily overnight fixings.
+        \warning telescopicValueDates optimizes the schedule for calculation speed,
+        but might fail to produce correct results if the coupon ages and new
+        O/N fixings come into play on which the couopon then depends
+    */
     class OvernightIndexedCoupon : public FloatingRateCoupon {
       public:
         OvernightIndexedCoupon(

--- a/QuantLib/ql/cashflows/overnightindexedcoupon.hpp
+++ b/QuantLib/ql/cashflows/overnightindexedcoupon.hpp
@@ -45,7 +45,8 @@ namespace QuantLib {
                     Spread spread = 0.0,
                     const Date& refPeriodStart = Date(),
                     const Date& refPeriodEnd = Date(),
-                    const DayCounter& dayCounter = DayCounter());
+                    const DayCounter& dayCounter = DayCounter(),
+                    const bool telescopicValueDates = false);
         //! \name Inspectors
         //@{
         //! fixing dates for the rates to be compounded
@@ -87,6 +88,7 @@ namespace QuantLib {
         OvernightLeg& withGearings(const std::vector<Real>& gearings);
         OvernightLeg& withSpreads(Spread spread);
         OvernightLeg& withSpreads(const std::vector<Spread>& spreads);
+        OvernightLeg& withTelescopicValueDates(const bool telescopicValueDates);
         operator Leg() const;
       private:
         Schedule schedule_;
@@ -96,6 +98,7 @@ namespace QuantLib {
         BusinessDayConvention paymentAdjustment_;
         std::vector<Real> gearings_;
         std::vector<Spread> spreads_;
+        bool telescopicValueDates_;
     };
 
 }

--- a/QuantLib/ql/indexes/swapindex.cpp
+++ b/QuantLib/ql/indexes/swapindex.cpp
@@ -210,7 +210,8 @@ namespace QuantLib {
             Rate fixedRate = 0.0;
             lastSwap_ = MakeOIS(tenor_, overnightIndex_, fixedRate)
                 .withEffectiveDate(valueDate(fixingDate))
-                .withFixedLegDayCount(dayCounter_);
+                .withFixedLegDayCount(dayCounter_)
+                .withTelescopicValueDates(true);
             lastFixingDate_ = fixingDate;
         }
         return lastSwap_;

--- a/QuantLib/ql/instruments/makeois.cpp
+++ b/QuantLib/ql/instruments/makeois.cpp
@@ -24,19 +24,19 @@
 
 namespace QuantLib {
 
-    MakeOIS::MakeOIS(const Period& swapTenor,
-                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                     Rate fixedRate,
-                     const Period& forwardStart)
-    : swapTenor_(swapTenor), overnightIndex_(overnightIndex),
-      fixedRate_(fixedRate), forwardStart_(forwardStart),
-      fixingDays_(2), paymentFrequency_(Annual),
-      rule_(DateGeneration::Forward),
-      endOfMonth_(1*Months<=swapTenor && swapTenor<=2*Years ? true : false),
-      type_(OvernightIndexedSwap::Payer), nominal_(1.0),
-      overnightSpread_(0.0),
-      fixedDayCount_(overnightIndex->dayCounter()),
-      engine_(new DiscountingSwapEngine(overnightIndex_->forwardingTermStructure())) {}
+    MakeOIS::MakeOIS(const Period &swapTenor,
+                     const boost::shared_ptr<OvernightIndex> &overnightIndex,
+                     Rate fixedRate, const Period &forwardStart)
+        : swapTenor_(swapTenor), overnightIndex_(overnightIndex),
+          fixedRate_(fixedRate), forwardStart_(forwardStart), fixingDays_(2),
+          paymentFrequency_(Annual), rule_(DateGeneration::Forward),
+          endOfMonth_(
+              1 * Months <= swapTenor && swapTenor <= 2 * Years ? true : false),
+          type_(OvernightIndexedSwap::Payer), nominal_(1.0),
+          overnightSpread_(0.0), fixedDayCount_(overnightIndex->dayCounter()),
+          engine_(new DiscountingSwapEngine(
+              overnightIndex_->forwardingTermStructure())),
+          telescopicValueDates_(false) {}
 
     MakeOIS::operator OvernightIndexedSwap() const {
         boost::shared_ptr<OvernightIndexedSwap> ois = *this;
@@ -87,7 +87,8 @@ namespace QuantLib {
                                       schedule,
                                       0.0, // fixed rate
                                       fixedDayCount_,
-                                      overnightIndex_, overnightSpread_);
+                                      overnightIndex_, overnightSpread_,
+                                      telescopicValueDates_);
             // ATM on the forecasting curve
             bool includeSettlementDateFlows = false;
             temp.setPricingEngine(boost::shared_ptr<PricingEngine>(
@@ -101,7 +102,8 @@ namespace QuantLib {
             OvernightIndexedSwap(type_, nominal_,
                                  schedule,
                                  usedFixedRate, fixedDayCount_,
-                                 overnightIndex_, overnightSpread_));
+                                 overnightIndex_, overnightSpread_,
+                                 telescopicValueDates_));
         ois->setPricingEngine(engine_);
         return ois;
     }
@@ -173,5 +175,12 @@ namespace QuantLib {
         overnightSpread_ = sp;
         return *this;
     }
+
+    MakeOIS& MakeOIS::withTelescopicValueDates(bool telescopicValueDates) {
+        telescopicValueDates_ = telescopicValueDates;
+        return *this;
+
+    }
+
 
 }

--- a/QuantLib/ql/instruments/makeois.hpp
+++ b/QuantLib/ql/instruments/makeois.hpp
@@ -60,6 +60,9 @@ namespace QuantLib {
 
         MakeOIS& withDiscountingTermStructure(
                   const Handle<YieldTermStructure>& discountingTermStructure);
+
+        MakeOIS &withTelescopicValueDates(const bool telescopicValueDates);
+
       private:
         Period swapTenor_;
         boost::shared_ptr<OvernightIndex> overnightIndex_;
@@ -79,6 +82,8 @@ namespace QuantLib {
         DayCounter fixedDayCount_;
 
         boost::shared_ptr<PricingEngine> engine_;
+
+        bool telescopicValueDates_;
     };
 
 }

--- a/QuantLib/ql/instruments/overnightindexedswap.cpp
+++ b/QuantLib/ql/instruments/overnightindexedswap.cpp
@@ -31,12 +31,14 @@ namespace QuantLib {
                     Rate fixedRate,
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread)
+                    Spread spread,
+                    bool telescopicValueDates)
     : Swap(2), type_(type),
       nominals_(std::vector<Real>(1, nominal)),
       paymentFrequency_(schedule.tenor().frequency()),
       fixedRate_(fixedRate), fixedDC_(fixedDC),
-      overnightIndex_(overnightIndex), spread_(spread) {
+        overnightIndex_(overnightIndex), spread_(spread),
+        telescopicValueDates_(telescopicValueDates) {
 
           initialize(schedule);
 
@@ -49,11 +51,13 @@ namespace QuantLib {
                     Rate fixedRate,
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread)
+                    Spread spread,
+                    bool telescopicValueDates)
     : Swap(2), type_(type), nominals_(nominals),
       paymentFrequency_(schedule.tenor().frequency()),
       fixedRate_(fixedRate), fixedDC_(fixedDC),
-      overnightIndex_(overnightIndex), spread_(spread) {
+        overnightIndex_(overnightIndex), spread_(spread),
+        telescopicValueDates_(telescopicValueDates) {
 
           initialize(schedule);
 
@@ -68,7 +72,8 @@ namespace QuantLib {
 
         legs_[1] = OvernightLeg(schedule, overnightIndex_)
             .withNotionals(nominals_)
-            .withSpreads(spread_);
+            .withSpreads(spread_)
+            .withTelescopicValueDates(telescopicValueDates_);
 
         for (Size j=0; j<2; ++j) {
             for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)

--- a/QuantLib/ql/instruments/overnightindexedswap.hpp
+++ b/QuantLib/ql/instruments/overnightindexedswap.hpp
@@ -44,7 +44,8 @@ namespace QuantLib {
                     Rate fixedRate,
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread = 0.0);
+                    Spread spread = 0.0,
+                    bool telescopicValueDates = false);
         OvernightIndexedSwap(
                     Type type,
                     std::vector<Real> nominals,
@@ -52,7 +53,8 @@ namespace QuantLib {
                     Rate fixedRate,
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread = 0.0);
+                    Spread spread = 0.0,
+                    bool telescopicValueDates = false);
         //! \name Inspectors
         //@{
         Type type() const { return type_; }
@@ -95,6 +97,7 @@ namespace QuantLib {
 
         boost::shared_ptr<OvernightIndex> overnightIndex_;
         Spread spread_;
+        bool telescopicValueDates_;
     };
 
 

--- a/QuantLib/ql/termstructures/yield/oisratehelper.cpp
+++ b/QuantLib/ql/termstructures/yield/oisratehelper.cpp
@@ -57,7 +57,8 @@ namespace QuantLib {
         //    be assigned a curve later; use a RelinkableHandle here
         swap_ = MakeOIS(tenor_, clonedOvernightIndex, 0.0)
             .withDiscountingTermStructure(discountRelinkableHandle_)
-            .withSettlementDays(settlementDays_);
+            .withSettlementDays(settlementDays_)
+            .withTelescopicValueDates(true);
 
         earliestDate_ = swap_->startDate();
         latestDate_ = swap_->maturityDate();
@@ -118,7 +119,8 @@ namespace QuantLib {
         swap_ = MakeOIS(Period(), clonedOvernightIndex, 0.0)
             .withDiscountingTermStructure(discountRelinkableHandle_)
             .withEffectiveDate(startDate)
-            .withTerminationDate(endDate);
+            .withTerminationDate(endDate)
+            .withTelescopicValueDates(true);
 
         earliestDate_ = swap_->startDate();
         latestDate_ = swap_->maturityDate();

--- a/QuantLib/test-suite/overnightindexedswap.hpp
+++ b/QuantLib/test-suite/overnightindexedswap.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2009 Roland Lichters
+ Copyright (C) 2014 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -31,6 +32,7 @@ class OvernightIndexedSwapTest {
     static void testFairSpread();
     static void testCachedValue();
     static void testBootstrap();
+    static void testSeasonedSwaps();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
OIS curves typically require much more time to boostrap than other interest rate curves. This ad hoc fix allows for faster computation, e.g. in case of an Eonia curve out to 50y by a factor of more than 100. 