### PR TITLE
Rewrite DiscreteHedging.java with faster execution speed

### DIFF
--- a/QuantLib-SWIG/Java/examples/DiscreteHedging.java
+++ b/QuantLib-SWIG/Java/examples/DiscreteHedging.java
@@ -1,6 +1,5 @@
-
 /*
- Copyright (C) 2008 Tito Ingargiola
+ Copyright (C) 2014 Felix Lee
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -16,371 +15,323 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
+/*  This example computes profit and loss of a discrete interval hedging
+    strategy and compares with the results of Derman & Kamal's (Goldman Sachs
+    Equity Derivatives Research) Research Note: "When You Cannot Hedge
+    Continuously: The Corrections to Black-Scholes"
+    http://www.ederman.com/emanuelderman/GSQSpapers/when_you_cannot_hedge.pdf
+
+    Suppose an option hedger sells an European option and receives the
+    Black-Scholes value as the options premium.
+    Then he follows a Black-Scholes hedging strategy, rehedging at discrete,
+    evenly spaced time intervals as the underlying stock changes. At
+    expiration, the hedger delivers the option payoff to the option holder,
+    and unwinds the hedge. We are interested in understanding the final
+    profit or loss of this strategy.
+
+    If the hedger had followed the exact Black-Scholes replication strategy,
+    re-hedging continuously as the underlying stock evolved towards its final
+    value at expiration, then, no matter what path the stock took, the final
+    P&L would be exactly zero. When the replication strategy deviates from
+    the exact Black-Scholes method, the final P&L may deviate from zero. This
+    deviation is called the replication error. When the hedger rebalances at
+    discrete rather than continuous intervals, the hedge is imperfect and the
+    replication is inexact. The more often hedging occurs, the smaller the
+    replication error.
+
+    We examine the range of possibilities, computing the replication error.
+*/
+
 package examples;
 
-import org.quantlib.Actual365Fixed;
+import org.quantlib.Option;
+import org.quantlib.PlainVanillaPayoff;
 import org.quantlib.BlackCalculator;
-import org.quantlib.BlackConstantVol;
-import org.quantlib.BlackScholesMertonProcess;
-import org.quantlib.BlackVolTermStructureHandle;
 import org.quantlib.Calendar;
+import org.quantlib.TARGET;
 import org.quantlib.Date;
 import org.quantlib.DayCounter;
-import org.quantlib.FlatForward;
-import org.quantlib.GaussianPathGenerator;
-import org.quantlib.GaussianRandomSequenceGenerator;
-import org.quantlib.Option;
-import org.quantlib.Path;
-import org.quantlib.PlainVanillaPayoff;
+import org.quantlib.Actual365Fixed;
 import org.quantlib.QuoteHandle;
-import org.quantlib.SamplePath;
 import org.quantlib.SimpleQuote;
-import org.quantlib.Statistics;
-import org.quantlib.TARGET;
-import org.quantlib.UniformRandomGenerator;
-import org.quantlib.UniformRandomSequenceGenerator;
 import org.quantlib.YieldTermStructureHandle;
+import org.quantlib.FlatForward;
+import org.quantlib.BlackVolTermStructureHandle;
+import org.quantlib.BlackConstantVol;
+import org.quantlib.BlackScholesMertonProcess;
+import org.quantlib.PseudoRandomMT;
+import org.quantlib.InvCumulativeMersenneTwisterGaussianRsg;
+import org.quantlib.PathGeneratorPseudoRandom;
+import org.quantlib.Path;
+import org.quantlib.PathPricerPath;
+import org.quantlib.Statistics;
+import org.quantlib.MonteCarloModelSingleVariatePseudoRandom;
 
-/**
- * DiscreteHedging Test app - java version of QuantLib/Examples/DiscreteHedging
- * to illustrate use of Quantlib's MonteCarlo functionality through supplied
- * SWIG interfaces.
- *
- * You need to run this with a correctly set library path and something like:
- *
- * -Djava.library.path=/usr/local/lib
- *
- * @author Tito Ingargiola
- **/
 public class DiscreteHedging {
-
-    static {  // Load QuantLib
-        try { System.loadLibrary("QuantLibJNI"); }
-        catch (RuntimeException e) { e.printStackTrace(); }
+    // Link up the quantlib
+    static {
+        try {
+            System.loadLibrary("QuantLibJNI");
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        }
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
+        final long startTime = System.currentTimeMillis();
 
-        long begin = System.currentTimeMillis();
-
-        double maturity = 1.0/12.0;   // 1 month
-        double strike = 100;
-        double underlying = 100;
+        double maturity = 1.0/12.0; // 1 month
+        double strike = 100.0;
+        double underlying = 100.0;
         double volatility = 0.20; // 20%
         double riskFreeRate = 0.05; // 5%
-        ReplicationError rp = new ReplicationError(Option.Type.Call, maturity,
-            strike, underlying, volatility, riskFreeRate);
+        ReplicationError rp = new ReplicationError(Option.Type.Call, maturity, strike,
+                                                   underlying, volatility, riskFreeRate);
 
         long scenarios = 50000;
-        long hedgesNum = 21;
+        long hedgesNum;
+
+        hedgesNum = 21;
         rp.compute(hedgesNum, scenarios);
 
         hedgesNum = 84;
         rp.compute(hedgesNum, scenarios);
 
-        long msecs = (System.currentTimeMillis()-begin);
-        System.out.println("\nRun completed in "+msecs+" ms.");
-    }
-
-    /**
-     * The ReplicationError class carries out Monte Carlo simulations to
-     * evaluate the outcome (the replication error) of the discrete hedging
-     * strategy over different, randomly generated scenarios of future stock
-     * price evolution.
-     **/
-    public static class ReplicationError {
-
-        public ReplicationError(Option.Type type, double maturity,
-            double strike, double s0, double sigma, double r ) {
-
-            type_ = type;
-            maturity_ = maturity;
-            strike_ = strike;
-            s0_ = s0;
-            sigma_ = sigma;
-            r_ = r;
-
-            // value of the option
-            double rDiscount = Math.exp(-r_ * maturity_);
-            double qDiscount = 1.0;
-            double forward = s0_ * qDiscount/rDiscount;
-            double stdDev = Math.sqrt(sigma_*sigma_*maturity);
-            BlackCalculator black = new BlackCalculator
-                (new PlainVanillaPayoff(type,strike),forward,stdDev,rDiscount);
-
-            System.out.printf("Option value: %2.5f \n\n",black.value());
-
-            // store option's vega, since Derman and Kamal's formula needs it
-            vega_ = black.vega(maturity_);
-
-            String fmt ="%-8s | %-8s | %-8s | %-8s | %-12s | %-8s | %-8s \n";
-            System.out.printf
-                (fmt, " ", " ", "P&L", "P&L", "Derman&Kamal", "P&L","P&L" );
-            System.out.printf(fmt, " samples", "trades", "mean", "std.dev",
-                "formula", "skewness","kurtosis" );
-            for (int i = 0; i < 78; i++) System.out.print("-");
-            System.out.println("-");
-        }
-
-        void compute(long nTimeSteps, long nSamples) {
-            assert nTimeSteps>0 : "the number of steps must be > 0";
-
-            /* Black-Scholes framework: the underlying stock price evolves
-               lognormally with a fixed known volatility that stays constant
-               throughout time. */
-            Calendar calendar = new TARGET();
-            Date today = Date.todaysDate();
-            DayCounter dayCounter = new Actual365Fixed();
-            QuoteHandle stateVariable = new QuoteHandle(new SimpleQuote(s0_));
-
-            YieldTermStructureHandle riskFreeRate =
-                new YieldTermStructureHandle
-                    (new FlatForward(today, r_, dayCounter));
-            YieldTermStructureHandle dividendYield =
-                new YieldTermStructureHandle
-                    (new FlatForward(today, 0.0, dayCounter));
-            BlackVolTermStructureHandle volatility =
-                new BlackVolTermStructureHandle(
-                    new BlackConstantVol(today, calendar, sigma_, dayCounter));
-            BlackScholesMertonProcess diffusion =
-                new BlackScholesMertonProcess
-                    (stateVariable,dividendYield, riskFreeRate, volatility);
-
-            // Black Scholes equation rules the path generator:
-            // at each step the log of the stock
-            // will have drift and sigma^2 variance
-             boolean brownianBridge = false;
-            GaussianRandomSequenceGenerator rsg =
-                new GaussianRandomSequenceGenerator
-                    (new UniformRandomSequenceGenerator
-                        (nTimeSteps,new UniformRandomGenerator(0)));
-            GaussianPathGenerator myPathGenerator =
-                new GaussianPathGenerator
-                    (diffusion,maturity_,nTimeSteps,rsg, brownianBridge);
-
-            /* Alternately you can modify the MonteCarloModel to take a
-             * GaussianSobolPathGenerator and uncomment these lines and
-             * comment those just above
-             *
-            GaussianLowDiscrepancySequenceGenerator rsg =
-                new GaussianLowDiscrepancySequenceGenerator
-                    (new UniformLowDiscrepancySequenceGenerator
-                            (nTimeSteps));
-            GaussianSobolPathGenerator myPathGenerator =
-                new GaussianSobolPathGenerator
-                    (diffusion,maturity_,nTimeSteps,rsg, brownianBridge);*/
-
-            ReplicationPathPricer myPathPricer = new ReplicationPathPricer
-                (type_,strike_, r_, maturity_, sigma_);
-
-            MonteCarloModel mcSimulation = new MonteCarloModel
-                (myPathGenerator, myPathPricer);
-
-            mcSimulation.addSamples(nSamples);
-
-            // the sampleAccumulator method
-            // gives access to all the methods of statisticsAccumulator
-            double PLMean  = mcSimulation.sampleAccumulator().mean();
-            double PLStDev =
-                mcSimulation.sampleAccumulator().standardDeviation();
-            double PLSkew  = mcSimulation.sampleAccumulator().skewness();
-            double PLKurt  = mcSimulation.sampleAccumulator().kurtosis();
-
-            // Derman and Kamal's formula
-            double theorStD = Math.sqrt(Math.PI/4/nTimeSteps)*vega_*sigma_;
-
-            String fmt =
-                "%-8d | %-8d | %-8.3f | %-8.2f | %-12.2f | %-8.2f | %-8.2f \n";
-            System.out.printf(fmt, nSamples, nTimeSteps, PLMean, PLStDev,
-                theorStD, PLSkew, PLKurt );
-        }
-
-        double maturity_;
-        Option.Type type_;
-        double strike_;
-        double s0_;
-        double sigma_;
-        double r_;
-        double vega_;
-    }
-
-    /**
-     * We pull the interface for a PathPricer into Java so we can
-     * support its implementation in Java while still relying upon QuantLib's
-     * powerful RNGs.
-     */
-    public static interface JPathPricer {
-
-        public double price(Path path);
-
-    }
-
-    // The key for the MonteCarlo simulation is to have a PathPricer that
-    // implements a value(const Path& path) method.
-    // This method prices the portfolio for each Path of the random variable
-    public static class ReplicationPathPricer implements JPathPricer {
-
-        public ReplicationPathPricer(Option.Type type,  double strike,
-            double r, double maturity, double sigma) {
-            assert strike > 0     : "Strike must be positive!";
-            assert maturity > 0 : "Risk free rate must be positive!";
-            assert r >= 0         : "Risk free rate must be positive or Zero!";
-            assert sigma >= 0     : "Volatility must be positive or Zero!";
-
-            type_         = type;
-            strike_     = strike;
-            r_             = r;
-            maturity_     = maturity;
-            sigma_         = sigma;
-        }
-
-        public double price(Path path) {
-
-            long n = path.length() - 1;
-            assert n > 0 : "The path can't be empty!";
-
-            // discrete hedging interval
-            double dt = maturity_ / n;
-
-            // For simplicity, we assume the stock pays no dividends.
-            double stockDividendYield = 0.0;
-
-            // let's start
-            double t = 0;
-
-            // stock value at t=0
-            double stock = path.front();
-
-            // money account at t=0
-            double money_account = 0.0;
-
-            /************************/
-            /*** the initial deal ***/
-            /************************/
-            // option fair price (Black-Scholes) at t=0
-            double rDiscount = Math.exp(-r_*maturity_);
-            double qDiscount = Math.exp(-stockDividendYield*maturity_);
-            double forward = stock*qDiscount/rDiscount;
-            double stdDev = Math.sqrt(sigma_*sigma_*maturity_);
-            PlainVanillaPayoff payoff = new PlainVanillaPayoff(type_,strike_);
-            BlackCalculator black = new BlackCalculator
-                (payoff,forward,stdDev,rDiscount);
-
-            // sell the option, cash in its premium
-            money_account += black.value();
-            // compute delta
-            double delta = black.delta(stock);
-            // delta-hedge the option buying stock
-            double stockAmount = delta;
-            money_account -= stockAmount*stock;
-            /**********************************/
-            /*** hedging during option life ***/
-            /**********************************/
-            for (long step = 0; step < n-1; step++){
-
-                // time flows
-                t += dt;
-
-                // accruing on the money account
-                money_account *= Math.exp( r_*dt );
-
-                // stock growth:
-                stock = path.value(step+1);
-
-                // recalculate option value at the current stock value,
-                // and the current time to maturity
-                rDiscount = Math.exp(-r_*(maturity_-t));
-                qDiscount = Math.exp(-stockDividendYield*(maturity_-t));
-
-                forward = stock*(qDiscount/rDiscount);
-
-                stdDev = Math.sqrt(sigma_*sigma_*(maturity_-t));
-                black = new BlackCalculator
-                    (new PlainVanillaPayoff(type_,strike_),forward,stdDev,rDiscount);
-
-                // recalculate delta
-                delta = black.delta(stock);
-
-                // re-hedging
-                money_account -= (delta - stockAmount)*stock;
-                stockAmount = delta;
-            }
-
-            /*************************/
-            /*** option expiration ***/
-            /*************************/
-            // last accrual on my money account
-            money_account *= Math.exp( r_*dt );
-            // last stock growth
-            stock = path.value(n);
-
-            // the hedger delivers the option payoff to the option holder
-            double optionPayoff =
-                (new PlainVanillaPayoff(type_, strike_)).getValue(stock);
-            money_account -= optionPayoff;
-
-            // and unwinds the hedge selling his stock position
-            money_account += stockAmount*stock;
-
-            // final Profit&Loss
-            return money_account;
-        }
-
-        double maturity_;
-        Option.Type type_;
-        double strike_;
-        double sigma_;
-        double r_;
-    }
-
-
-    /**
-     * We pull the MonteCarloModel into Java so that we can enable the
-     * implementation in java of our PathPricer
-     */
-    public static class MonteCarloModel {
-
-        /** convenience ctor **/
-        public MonteCarloModel
-            (GaussianPathGenerator gpg, JPathPricer pathpricer) {
-            this(gpg,pathpricer,false, null);
-        }
-
-        /** complete ctor **/
-           public MonteCarloModel(GaussianPathGenerator gpg,
-                JPathPricer pathpricer, boolean antitheticVariate,
-                Statistics stats ) {
-            assert gpg != null : "PathGenerator must not be null!";
-            assert pathpricer != null : "PathPricer must not be null!";
-            gpg_ = gpg;
-            ppricer_ = pathpricer;
-            stats_ = (stats==null) ? new Statistics() : stats;
-            av_ = antitheticVariate;
-        }
-
-        public Statistics sampleAccumulator () { return stats_; }
-
-
-        public void addSamples( long samples ) {
-            for(long j = 0; j < samples; j++) {
-
-                SamplePath path = gpg_.next();
-                double price = ppricer_.price(path.value());
-                if ( av_ ) {
-                    path = gpg_.antithetic();
-                    double price2 = ppricer_.price(path.value());
-                    stats_.add((price+price2)/2.0, path.weight());
-
-                } else {
-                    stats_.add(price, path.weight());
-                }
-           }
-
-        }
-        final boolean av_;
-        final GaussianPathGenerator gpg_;
-        final JPathPricer ppricer_;
-        final Statistics stats_;
+        final long endTime = System.currentTimeMillis();
+        System.out.println("\nRun completed in " + (endTime - startTime)/1000 + " s\n");
     }
 }
 
+class ReplicationError {
+    private double maturity;
+    private PlainVanillaPayoff payoff;
+    private double s0;
+    private double sigma;
+    private double r;
+    private double vega;
+
+    public static final double M_PI = 3.141592653589793238462643383280;
+
+    ReplicationError(Option.Type type,
+                     double maturity,
+                     double strike,
+                     double s0,
+                     double sigma,
+                     double r) {
+        this.maturity = maturity;
+        this.payoff = new PlainVanillaPayoff(type, strike);
+        this.s0 = s0;
+        this.sigma = sigma;
+        this.r = r;
+
+        // value of the option
+        double rDiscount = Math.exp(-r*maturity);
+        double qDiscount = 1.0;
+        double forward = s0*qDiscount/rDiscount;
+        double stdDev = Math.sqrt(sigma*sigma*maturity);
+        BlackCalculator black = new BlackCalculator(payoff,forward,stdDev,rDiscount);
+        System.out.printf("\nOption value: %1$7.5f\n", black.value());
+
+        // store option's vega, since Derman and Kamal's formula needs it
+        vega = black.vega(maturity);
+
+        System.out.println("");
+        System.out.print("         |");
+        System.out.print("          |");
+        System.out.print("      P&L |");
+        System.out.print("      P&L |");
+        System.out.print(" Derman&Kamal |");
+        System.out.println("      P&L |      P&L");
+
+        System.out.print(" samples |");
+        System.out.print("   trades |");
+        System.out.print("     mean |");
+        System.out.print(" std.dev. |");
+        System.out.print("      formula |");
+        System.out.println(" skewness | kurtosis");
+
+        System.out.print("-------------------------");
+        System.out.print("-------------------------");
+        System.out.println("----------------------------");
+
+    }
+
+    // the actual replication error computation
+    // The computation over nSamples paths of the P&L distribution
+    void compute(long nTimeSteps, long nSamples) {
+        // hedging interval
+        // Time tau = maturity_ / nTimeSteps;
+
+        // Black-Scholes framework: the underlying stock price evolves
+        // lognormally with a fixed known volatility that stays constant
+        // throughout time.
+        Calendar calendar = new TARGET();
+        Date today = Date.todaysDate();
+        DayCounter dayCount = new Actual365Fixed();
+        QuoteHandle stateVariable = new QuoteHandle(new SimpleQuote(s0));
+        YieldTermStructureHandle riskFreeRate =
+            new YieldTermStructureHandle(new FlatForward(today, r, dayCount));
+        YieldTermStructureHandle dividendYield =
+            new YieldTermStructureHandle(new FlatForward(today, 0.0, dayCount));
+        BlackVolTermStructureHandle volatility =
+            new BlackVolTermStructureHandle(new BlackConstantVol(today, calendar,
+                                                                 sigma, dayCount));
+        BlackScholesMertonProcess diffusion =
+            new BlackScholesMertonProcess(stateVariable, dividendYield, riskFreeRate,
+                                          volatility);
+
+        // Black Scholes equation rules the path generator:
+        // at each step the log of the stock
+        // will have drift and sigma^2 variance
+        InvCumulativeMersenneTwisterGaussianRsg rsg =
+            PseudoRandomMT.make_sequence_generator(nTimeSteps, 0);
+
+        boolean brownianBridge = false;
+
+        PathGeneratorPseudoRandom myPathGenerator =
+            new PathGeneratorPseudoRandom(diffusion, maturity, nTimeSteps, rsg, brownianBridge);
+
+        // The replication strategy's Profit&Loss is computed for each path
+        // of the stock. The path pricer knows how to price a path using its
+        // value() method
+        PathPricerPath myPathPricer =
+            new ReplicationPathPricer(payoff.optionType(), payoff.strike(), r, maturity, sigma);
+
+        // a statistics accumulator for the path-dependant Profit&Loss values
+        Statistics statisticsAccumulator = new Statistics();
+
+        MonteCarloModelSingleVariatePseudoRandom MCSimulation =
+            new MonteCarloModelSingleVariatePseudoRandom(myPathGenerator,
+                                                         myPathPricer,
+                                                         statisticsAccumulator,
+                                                         false);
+
+        // the model simulates nSamples paths
+        MCSimulation.addSamples(nSamples);
+
+        // the sampleAccumulator method
+        // gives access to all the methods of statisticsAccumulator
+        double PLMean  = MCSimulation.sampleAccumulator().mean();
+        double PLStDev = MCSimulation.sampleAccumulator().standardDeviation();
+        double PLSkew  = MCSimulation.sampleAccumulator().skewness();
+        double PLKurt  = MCSimulation.sampleAccumulator().kurtosis();
+
+        // Derman and Kamal's formula
+        double theorStD = Math.sqrt(M_PI/4/nTimeSteps)*vega*sigma;
+
+        System.out.printf("%1$8d |", nSamples);
+        System.out.printf("%1$9d |", nTimeSteps);
+        System.out.printf("%1$9.3f |", PLMean);
+        System.out.printf("%1$9.2f |", PLStDev);
+        System.out.printf("%1$13.2f |", theorStD);
+        System.out.printf("%1$9.2f |", PLSkew);
+        System.out.printf("%1$9.2f\n", PLKurt);
+    }
+}
+
+// The key for the MonteCarlo simulation is to have a PathPricer that
+// implements a value(const Path& path) method.
+// This method prices the portfolio for each Path of the random variable
+class ReplicationPathPricer extends PathPricerPath {
+    private Option.Type type;
+    private double strike;
+    private double r;
+    private double maturity;
+    private double sigma;
+
+    // real constructor
+    public ReplicationPathPricer(Option.Type type, double strike, double r, double maturity,
+                                 double sigma) {
+        this.type = type;
+        this.strike = strike;
+        this.r = r;
+        this.maturity = maturity;
+        this.sigma = sigma;
+    }
+
+    public double getValue(Path path) {
+
+        long n = path.length()-1;
+
+        // discrete hedging interval
+        double dt = maturity/n;
+
+        // For simplicity, we assume the stock pays no dividends.
+        double stockDividendYield = 0.0;
+
+        // let's start
+        double t = 0.0;
+
+        // stock value at t=0
+        double stock = path.front();
+
+        // money account at t=0
+        double money_account = 0.0;
+
+        /************************/
+        /*** the initial deal ***/
+        /************************/
+        // option fair price (Black-Scholes) at t=0
+        double rDiscount = Math.exp(-r*maturity);
+        double qDiscount = Math.exp(-stockDividendYield*maturity);
+        double forward = stock*qDiscount/rDiscount;
+        double stdDev = Math.sqrt(sigma*sigma*maturity);
+        PlainVanillaPayoff payoff = new PlainVanillaPayoff(type, strike);
+        BlackCalculator black = new BlackCalculator(payoff, forward, stdDev, rDiscount);
+        // sell the option, cash in its premium
+        money_account += black.value();
+        // compute delta
+        double delta = black.delta(stock);
+        // delta-hedge the option buying stock
+        double stockAmount = delta;
+        money_account -= stockAmount*stock;
+
+        /**********************************/
+        /*** hedging during option life ***/
+        /**********************************/
+        for (long step = 0; step < n-1; step++) {
+
+            // time flows
+            t += dt;
+
+            // accruing on the money account
+            money_account *= Math.exp(r*dt);
+
+            // stock growth
+            stock = path.value(step+1);
+
+            // recalculate option value at the current stock value,
+            // and the current time to maturity
+            rDiscount = Math.exp(-r*(maturity-t));
+            qDiscount = Math.exp(-stockDividendYield*(maturity-t));
+            forward = stock*qDiscount/rDiscount;
+            stdDev = Math.sqrt(sigma*sigma*(maturity-t));
+            BlackCalculator black_recalc = new BlackCalculator(payoff, forward, stdDev, rDiscount);
+
+            // recalculate delta
+            delta = black_recalc.delta(stock);
+ 
+            // re-hedging
+            money_account -= (delta - stockAmount)*stock;
+            stockAmount = delta;
+        }
+
+        /*************************/
+        /*** option expiration ***/
+        /*************************/
+        // last accrual on my money account
+        money_account *= Math.exp(r*dt);
+        // last stock growth
+        stock = path.value(n);
+
+        // the hedger delivers the option payoff to the option holder
+        double optionPayoff = new PlainVanillaPayoff(type, strike).getValue(stock);
+        money_account -= optionPayoff;
+
+        // and unwinds the hedge selling his stock position
+        money_account += stockAmount*stock;
+
+        // final Profit&Loss
+        return money_account;
+    }
+}

--- a/QuantLib-SWIG/SWIG/quantlib.i
+++ b/QuantLib-SWIG/SWIG/quantlib.i
@@ -19,9 +19,9 @@
 */
 
 #if defined(SWIGRUBY)
-%module QuantLibc
+%module (directors="1") QuantLibc
 #elif defined(SWIGCSHARP)
-%module NQuantLibc
+%module (directors="1") NQuantLibc
 #elif defined(SWIGJAVA)
 %module(directors="1") QuantLib
 #else

--- a/QuantLib-SWIG/SWIG/randomnumbers.i
+++ b/QuantLib-SWIG/SWIG/randomnumbers.i
@@ -2,6 +2,7 @@
 /*
  Copyright (C) 2003 Ferdinando Ametrano
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2014 Felix Lee 
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -263,5 +264,31 @@ class GaussianLowDiscrepancySequenceGenerator {
     Size dimension() const;
 };
 
+/*************** PseudoRandomMT ******************/
+%{
+using QuantLib::GenericPseudoRandom;
+%}
+
+template <class URNG, class IC>
+struct GenericPseudoRandom {
+    // typedefs
+    typedef URNG urng_type;
+    typedef InverseCumulativeRng<urng_type,IC> rng_type;
+    typedef RandomSequenceGenerator<urng_type> ursg_type;
+    typedef InverseCumulativeRsg<ursg_type,IC> rsg_type;
+    // more traits
+    enum { allowsErrorEstimate = 1 };
+    // factory
+    static rsg_type make_sequence_generator(Size dimension,
+                                            BigNatural seed) {
+        ursg_type g(dimension, seed);
+        return (icInstance ? rsg_type(g, *icInstance) : rsg_type(g));
+    }
+    // data
+    static boost::shared_ptr<IC> icInstance;
+};
+
+%template(PseudoRandomMT)
+    GenericPseudoRandom<MersenneTwisterUniformRng,InverseCumulativeNormal>;
 
 #endif


### PR DESCRIPTION
- Rewrite DiscreteHedging.java example using SWIG director for callback
  and SWIG "boost_shared_ptr.i" to wrap the boost::shared_ptr<T> obj in
  MonteCarloModel class
- Execution time is 28sec while the previous code is 44sec
- Modify the following SWIG interface files to support my java code:
  1. quantlib.i: add (directors="1") to enable the directors feature
  2. randomnumbers.i: add PseudoRandomMT class
  3. montecarlo.i: add PathGeneratorPseudoRandom, PathPricerPath and
     MonteCarloModelSingleVariatePseudoRandom classes
- BTW, a warning pop out when generating swig wrapper because the name
  "shared_ptr" in SWIG "boost_shared_ptr.i" crashes with the one defined
  in "common.i". Anyway it won't affect the compilation.
