### PR TITLE
Added China Inter Bank Holiday calendar and holiday calendar for the year 2014

### DIFF
--- a/QuantLib/ql/time/calendars/china.cpp
+++ b/QuantLib/ql/time/calendars/china.cpp
@@ -26,10 +26,14 @@ namespace QuantLib {
     China::China(Market m) {
         // all calendar instances share the same implementation instance
         static boost::shared_ptr<Calendar::Impl> sseImpl(new China::SseImpl);
+		static boost::shared_ptr<Calendar::Impl> IBImpl(new China::ChinaIB);
         switch (m) {
           case SSE:
             impl_ = sseImpl;
             break;
+		  case IB:
+			impl_ = IBImpl;
+			break;
           default:
             QL_FAIL("unknown market");
         }
@@ -56,6 +60,7 @@ namespace QuantLib {
             || (y == 2011 && d == 3 && m == January)
             || (y == 2012 && (d == 2 || d == 3) && m == January)
             || (y == 2013 && d <= 3 && m == January)
+			|| (y == 2014 && d == 1 && m == January)
             // Chinese New Year
             || (y == 2004 && d >= 19 && d <= 28 && m == January)
             || (y == 2005 && d >=  7 && d <= 15 && m == February)
@@ -68,6 +73,8 @@ namespace QuantLib {
             || (y == 2011 && d >= 2 && d <= 8 && m == February)
             || (y == 2012 && d >= 23 && d <= 28 && m == January)
             || (y == 2013 && d >= 11 && d <= 15 && m == February)
+			|| (y == 2014 && d >= 31 && m == January)
+			|| (y == 2014 && d <= 6 && m == February)
             // Ching Ming Festival
             || (y <= 2008 && d == 4 && m == April)
             || (y == 2009 && d == 6 && m == April)
@@ -75,6 +82,7 @@ namespace QuantLib {
             || (y == 2011 && d >=3 && d <= 5 && m == April)
             || (y == 2012 && d >= 2 && d <= 4 && m == April)
             || (y == 2013 && d >= 4 && d <= 5 && m == April)
+			|| (y == 2014 && d == 7 && m == April)
             // Labor Day
             || (y <= 2007 && d >= 1 && d <= 7 && m == May)
             || (y == 2008 && d >= 1 && d <= 2 && m == May)
@@ -85,6 +93,7 @@ namespace QuantLib {
                               (d == 1 && m == May)))
             || (y == 2013 && ((d >= 29 && m == April) ||
                               (d == 1 && m == May)))
+			|| (y == 2014 && d >= 1 && d <=3 && m == May)
             // Tuen Ng Festival
             || (y <= 2008 && d == 9 && m == June)
             || (y == 2009 && (d == 28 || d == 29) && m == May)
@@ -92,12 +101,14 @@ namespace QuantLib {
             || (y == 2011 && d >= 4 && d <= 6 && m == June)
             || (y == 2012 && d >= 22 && d <= 24 && m == June)
             || (y == 2013 && d >= 10 && d <= 12 && m == June)
+			|| (y == 2014 && d == 2 && m == June)
             // Mid-Autumn Festival
             || (y <= 2008 && d == 15 && m == September)
             || (y == 2010 && d >= 22 && d <= 24 && m == September)
             || (y == 2011 && d >= 10 && d <= 12 && m == September)
             || (y == 2012 && d == 30 && m == September)
             || (y == 2013 && d >= 19 && d <= 20 && m == September)
+			|| (y == 2014 && d == 8 && m == September)
             // National Day
             || (y <= 2007 && d >= 1 && d <= 7 && m == October)
             || (y == 2008 && ((d >= 29 && m == September) ||
@@ -107,10 +118,47 @@ namespace QuantLib {
             || (y == 2011 && d >= 1 && d <= 7 && m == October)
             || (y == 2012 && d >= 1 && d <= 7 && m == October)
             || (y == 2013 && d >= 1 && d <= 7 && m == October)
+			|| (y == 2014 && d >= 1 && d <= 7 && m == October)
             )
             return false;
         return true;
     }
+
+	bool China::ChinaIB::isWeekend(Weekday w) const {
+		return w == Saturday || w == Sunday;
+	}
+
+	bool China::ChinaIB::isBusinessDay(const Date& date) const {
+
+		bool isNormalBizDay = sseImpl->isBusinessDay(date);
+
+		if(isNormalBizDay) {
+			// If it is already a SSE business day, it must be a IB business day
+			return isNormalBizDay;
+		} else {
+			const std::set<Date>& badWeekendList = badWeekends();
+			if(badWeekendList.find(date) != badWeekendList.end())
+				return true;
+			else
+				return false;
+		}
+	}
+
+	const std::set<Date>& China::ChinaIB::badWeekends() const {
+
+		// Hard coded working weekends
+
+		static const std::vector<Date> vec
+			= boost::assign::list_of<Date>
+			// 2013
+			(Date(5,Jan,2013))(Date(6,Jan,2013))(Date(16,Feb,2013))(Date(17,Feb,2013))(Date(7,Apr,2013))(Date(27,Apr,2013))(Date(28,Apr,2013))
+			(Date(8,Jun,2013))(Date(9,Jun,2013))(Date(22,Sep,2013))(Date(29,Sep,2013))(Date(12,Oct,2013))
+			// 2014
+			(Date(26,Jan,2014))(Date(8,Feb,2014))(Date(4,May,2014))(Date(28,Sep,2014))(Date(11,Oct,2014));
+
+		static const std::set<Date> badWeekendList(vec.begin(), vec.end());
+		return badWeekendList;
+	}
 
 }
 

--- a/QuantLib/ql/time/calendars/china.hpp
+++ b/QuantLib/ql/time/calendars/china.hpp
@@ -26,6 +26,9 @@
 #define quantlib_chinese_calendar_hpp
 
 #include <ql/time/calendar.hpp>
+#include <set>
+#include <vector>
+#include <boost/assign.hpp>
 
 namespace QuantLib {
 
@@ -49,7 +52,8 @@ namespace QuantLib {
         <li>Mid-Autumn Festival</li>
         </ul>
 
-        Data from <http://www.sse.com.cn/>
+        Sse Data from <http://www.sse.com.cn/>
+		ChinaIB Data from <http://www.chinamoney.com.cn/>
 
         \ingroup calendars
     */
@@ -61,8 +65,24 @@ namespace QuantLib {
             bool isWeekend(Weekday) const;
             bool isBusinessDay(const Date&) const;
         };
+
+		class ChinaIB : public Calendar::Impl {
+		public:
+			ChinaIB() {
+				sseImpl = boost::shared_ptr<Calendar::Impl>(new China::SseImpl);
+			}
+			std::string name() const { return "China inter bank market";}
+			bool isWeekend(Weekday) const;
+			bool isBusinessDay(const Date&) const;
+
+		private:
+			boost::shared_ptr<Calendar::Impl> sseImpl;
+
+			const std::set<Date>& badWeekends() const;
+		};
       public:
-        enum Market { SSE    //!< Shanghai stock exchange
+        enum Market { SSE,    //!< Shanghai stock exchange
+			          IB
         };
         China(Market m = SSE);
     };


### PR DESCRIPTION
China Inter Bank holidy schedule is different from SSE (Shanghai
Securities Exchange). Some weekends are good working days for inter bank
market. Now the working weekends are hard coded for the years 2013 and
2014
