### PR TITLE
optimize matrix multiplication

### DIFF
--- a/QuantLib/ql/math/matrix.hpp
+++ b/QuantLib/ql/math/matrix.hpp
@@ -527,12 +527,14 @@ namespace QuantLib {
                    m1.rows() << "x" << m1.columns() << ", " <<
                    m2.rows() << "x" << m2.columns() << ") cannot be "
                    "multiplied");
-        Matrix result(m1.rows(),m2.columns());
-        for (Size i=0; i<result.rows(); i++)
-            for (Size j=0; j<result.columns(); j++)
-                result[i][j] =
-                    std::inner_product(m1.row_begin(i), m1.row_end(i),
-                                       m2.column_begin(j), 0.0);
+        Matrix result(m1.rows(),m2.columns(),0.0);
+        for (Size i=0; i<result.rows(); ++i) {
+            for (Size k=0; k<m1.columns(); ++k) {
+                for (Size j=0; j<result.columns(); ++j) {
+                    result[i][j] += m1[i][k]*m2[k][j];
+                }
+            }
+        }
         return result;
     }
 


### PR DESCRIPTION
This seems to be an easy way to speed up the (native) matrix multiplication in QuantLib: There is a nice article on matrix multiplication here http://www.heise.de/ct/inhalt/2014/12/176/ (in german only though), from which I just took the part of (explicit loops and) using a loop order i-k-j instead of i-j-k. The results might well depend on optimization level and target; with clang 3.5.0 -O3 and x86_64 under linux I get the following timings for the test code under https://gist.github.com/pcaspers/bcc61ff74ae50bc2d9b3 which performs A*B with 1024x1024 matrices A and B

Original Code            10.59s
Explicit Loops i-j-k       8.01s
Explicit Loops i-k-j       0.96s
