### PR TITLE
add missing notifications / recompute ATM cube after section calibration

### DIFF
--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube1.cpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube1.cpp
@@ -652,6 +652,7 @@ namespace QuantLib {
         parametersGuess_.updateInterpolators();
         sabrCalibrationSection(marketVolCube_, sparseParameters_, swapTenor);
 
+        volCubeAtmCalibrated_ = marketVolCube_;
         if (isAtmCalibrated_) {
             fillVolatilityCube();
             sabrCalibrationSection(volCubeAtmCalibrated_, denseParameters_,


### PR DESCRIPTION
this is parallel to a similar fix in pull request #118 (so no need to merge, if the latter is accepted)
