### PR TITLE
Calculate binomial delta/gamma using Hull formulas

### DIFF
--- a/QuantLib/ql/pricingengines/vanilla/binomialengine.hpp
+++ b/QuantLib/ql/pricingengines/vanilla/binomialengine.hpp
@@ -125,36 +125,47 @@ namespace QuantLib {
         option.initialize(lattice, maturity);
 
         // Partial derivatives calculated from various points in the
-        // binomial tree (Odegaard)
+        // binomial tree 
+        // (see J.C.Hull, "Options, Futures and other derivatives", 6th edition, pp 397/398)
 
-        // Rollback to third-last step, and get underlying price (s2) &
+        // Rollback to third-last step, and get underlying prices (s2) &
         // option values (p2) at this point
         option.rollback(grid[2]);
         Array va2(option.values());
         QL_ENSURE(va2.size() == 3, "Expect 3 nodes in grid at second step");
-        Real p2h = va2[2]; // high-price
-        Real s2 = lattice->underlying(2, 2); // high price
+        Real p2u = va2[2]; // up
+        Real p2m = va2[1]; // mid
+        Real p2d = va2[0]; // down (low)
+        Real s2u = lattice->underlying(2, 2); // up price
+        Real s2m = lattice->underlying(2, 1); // middle price
+        Real s2d = lattice->underlying(2, 0); // down (low) price
 
-        // Rollback to second-last step, and get option value (p1) at
+        // calculate gamma by taking the first derivate of the two deltas
+        Real delta2u = (p2u - p2m)/(s2u-s2m);
+        Real delta2d = (p2m-p2d)/(s2m-s2d);
+        Real gamma = (delta2u - delta2d) / ((s2u-s2d)/2);
+
+        // Rollback to second-last step, and get option values (p1) at
         // this point
         option.rollback(grid[1]);
         Array va(option.values());
         QL_ENSURE(va.size() == 2, "Expect 2 nodes in grid at first step");
-        Real p1 = va[1];
+        Real p1u = va[1];
+        Real p1d = va[0];
+        Real s1u = lattice->underlying(1, 1); // up (high) price
+        Real s1d = lattice->underlying(1, 0); // down (low) price
+
+        Real delta = (p1u - p1d) / (s1u - s1d);
 
         // Finally, rollback to t=0
         option.rollback(0.0);
         Real p0 = option.presentValue();
         Real s1 = lattice->underlying(1, 1);
 
-        // Calculate partial derivatives
-        Real delta0 = (p1-p0)/(s1-s0);   // dp/ds
-        Real delta1 = (p2h-p1)/(s2-s1);  // dp/ds
-
         // Store results
         results_.value = p0;
-        results_.delta = delta0;
-        results_.gamma = 2.0*(delta1-delta0)/(s2-s0);    //d(delta)/ds
+        results_.delta = delta;
+        results_.gamma = gamma;
         results_.theta = blackScholesTheta(process_,
                                            results_.value,
                                            results_.delta,


### PR DESCRIPTION
Calculates binomial delta/gamma using only data at the same time point, instead of a different times.  We found it more stable and gives values nearer to other (commercial) pricing systems.
No changes on Quantlib tests.
