### PR TITLE
simultabeous curve bootstrap

### DIFF
--- a/QuantLib/ql/cashflows/overnightindexedcoupon.cpp
+++ b/QuantLib/ql/cashflows/overnightindexedcoupon.cpp
@@ -109,7 +109,94 @@ namespace QuantLib {
           protected:
             const OvernightIndexedCoupon* coupon_;
         };
+
     }
+
+	void ArithmeticAveragedOvernightIndexedCouponPricer::initialize(const FloatingRateCoupon& coupon) {
+        coupon_ = dynamic_cast<const OvernightIndexedCoupon*>(&coupon);
+        QL_ENSURE(coupon_, "wrong coupon type");
+    }
+
+    Rate ArithmeticAveragedOvernightIndexedCouponPricer::swapletRate() const {
+
+        shared_ptr<OvernightIndex> index =
+            dynamic_pointer_cast<OvernightIndex>(coupon_->index());
+
+        const vector<Date>& fixingDates = coupon_->fixingDates();
+        const vector<Time>& dt = coupon_->dt();
+
+        Size n = dt.size(),
+                i = 0;
+
+        Real accumulatedRate = 0.0;
+
+        // already fixed part
+        Date today = Settings::instance().evaluationDate();
+        while (i<n && fixingDates[i]<today) {
+            // rate must have been fixed
+            Rate pastFixing = IndexManager::instance().getHistory(
+                                        index->name())[fixingDates[i]];
+            QL_REQUIRE(pastFixing != Null<Real>(),
+                        "Missing " << index->name() <<
+                        " fixing for " << fixingDates[i]);
+            accumulatedRate += pastFixing*dt[i];
+            ++i;
+        }
+
+        // today is a border case
+        if (i<n && fixingDates[i] == today) {
+            // might have been fixed
+            try {
+                Rate pastFixing = IndexManager::instance().getHistory(
+                                        index->name())[fixingDates[i]];
+                if (pastFixing != Null<Real>()) {
+					accumulatedRate += pastFixing*dt[i];
+                    ++i;
+                } else {
+                    ;   // fall through and forecast
+                }
+            } catch (Error&) {
+                ;       // fall through and forecast
+            }
+        }
+
+        // forward part using telescopic property in order
+        // to avoid the evaluation of multiple forward fixings
+        if (i<n) {
+            Handle<YieldTermStructure> curve =
+                index->forwardingTermStructure();
+            QL_REQUIRE(!curve.empty(),
+                        "null term structure set to this instance of "<<
+                        index->name());
+
+            const vector<Date>& dates = coupon_->valueDates();
+            DiscountFactor startDiscount = curve->discount(dates[i]);
+            DiscountFactor endDiscount = curve->discount(dates[n]);
+
+            accumulatedRate += log(startDiscount/endDiscount) - convAdj1(curve->timeFromReference(dates[i]),
+																		 curve->timeFromReference(dates[n]))
+															  - convAdj2(curve->timeFromReference(dates[i]),
+																		 curve->timeFromReference(dates[n]));
+			
+        }
+
+        Rate rate = accumulatedRate / coupon_->accrualPeriod();
+        return coupon_->gearing() * rate + coupon_->spread();
+    }
+
+	Real ArithmeticAveragedOvernightIndexedCouponPricer::convAdj1(Time ts, Time te) const {
+		Real vol = vol_->value();
+		Real k = meanReversion_->value();
+		return vol * vol / ( 4.0 * pow(k, 3.0) ) * ( 1.0 - exp(-2.0*k*ts)) * pow(( 1.0 - exp(-k*(te-ts)) ), 2.0);
+	}
+
+	Real ArithmeticAveragedOvernightIndexedCouponPricer::convAdj2(Time ts, Time te) const {
+		Real vol = vol_->value();
+		Real k = meanReversion_->value();
+		return vol * vol / ( 2.0 * pow( k, 2.0) ) * ( ( te - ts) -  
+													   pow( 1.0 - exp(-k*(te - ts)), 2.0) / k - 
+													   ( 1.0 - exp(-2.0*k*(te - ts))) / ( 2.0 * k));
+	}
 
     OvernightIndexedCoupon::OvernightIndexedCoupon(
                     const Date& paymentDate,

--- a/QuantLib/ql/cashflows/overnightindexedcoupon.hpp
+++ b/QuantLib/ql/cashflows/overnightindexedcoupon.hpp
@@ -28,6 +28,8 @@
 #include <ql/cashflows/floatingratecoupon.hpp>
 #include <ql/indexes/iborindex.hpp>
 #include <ql/time/schedule.hpp>
+#include <ql/cashflows/couponpricer.hpp>
+#include <ql/quotes/simplequote.hpp>
 
 namespace QuantLib {
 
@@ -96,6 +98,33 @@ namespace QuantLib {
         BusinessDayConvention paymentAdjustment_;
         std::vector<Real> gearings_;
         std::vector<Spread> spreads_;
+    };
+
+	/*! pricer for arithmetically averaged overnight indexed coupons
+		Reference: Katsumi Takada 2011, Valuation of Arithmetically Average of Fed Funds Rates and Construction of the US Dollar Swap Yield Curve
+	*/
+	class ArithmeticAveragedOvernightIndexedCouponPricer : public FloatingRateCouponPricer {
+        public:
+		ArithmeticAveragedOvernightIndexedCouponPricer(Handle<Quote> meanReversion = Handle<Quote>(boost::shared_ptr<Quote> (new SimpleQuote(0.03))),
+													   Handle<Quote> vol = Handle<Quote>(boost::shared_ptr<Quote> (new SimpleQuote(0.00)))) 
+		: meanReversion_(meanReversion), vol_(vol) {}
+        void initialize(const FloatingRateCoupon& coupon);
+        Rate swapletRate() const;
+
+        Real swapletPrice() const { QL_FAIL("swapletPrice not available");  }
+        Real capletPrice(Rate) const { QL_FAIL("capletPrice not available"); }
+        Rate capletRate(Rate) const { QL_FAIL("capletRate not available"); }
+        Real floorletPrice(Rate) const { QL_FAIL("floorletPrice not available"); }
+        Rate floorletRate(Rate) const { QL_FAIL("floorletRate not available"); }
+
+		Real meanReversion() const { meanReversion_->value(); };
+		Real volatility() const { vol_->value(); };
+        protected:
+		Real convAdj1(Time ts, Time te) const;
+		Real convAdj2(Time ts, Time te) const;
+        const OvernightIndexedCoupon* coupon_;
+		Handle<Quote> meanReversion_;
+		Handle<Quote> vol_;
     };
 
 }

--- a/QuantLib/ql/instruments/Makefile.am
+++ b/QuantLib/ql/instruments/Makefile.am
@@ -31,11 +31,13 @@ this_include_HEADERS = \
     forwardrateagreement.hpp \
     forwardvanillaoption.hpp \
     impliedvolatility.hpp \
+    iboroisbasisswap.hpp \
     inflationcapfloor.hpp \
     lookbackoption.hpp \
     makecapfloor.hpp \
     makecms.hpp \
     makeois.hpp \
+    makeiboroisbasisswap.hpp \
     makeswaption.hpp \
     makevanillaswap.hpp \
     makeyoyinflationcapfloor.hpp \
@@ -82,11 +84,13 @@ libInstruments_la_SOURCES = \
     forwardrateagreement.cpp \
     forwardvanillaoption.cpp \
     impliedvolatility.cpp \
+    iboroisbasisswap.cpp \
     inflationcapfloor.cpp \
     lookbackoption.cpp \
     makecapfloor.cpp \
     makecms.cpp \
     makeois.cpp \
+    makeiboroisbasisswap.cpp \
     makeswaption.cpp \
     makevanillaswap.cpp \
     makeyoyinflationcapfloor.cpp \

--- a/QuantLib/ql/instruments/all.hpp
+++ b/QuantLib/ql/instruments/all.hpp
@@ -26,11 +26,13 @@
 #include <ql/instruments/forwardrateagreement.hpp>
 #include <ql/instruments/forwardvanillaoption.hpp>
 #include <ql/instruments/impliedvolatility.hpp>
+#include <ql/instruments/iboroisbasisswap.hpp>
 #include <ql/instruments/inflationcapfloor.hpp>
 #include <ql/instruments/lookbackoption.hpp>
 #include <ql/instruments/makecapfloor.hpp>
 #include <ql/instruments/makecms.hpp>
 #include <ql/instruments/makeois.hpp>
+#include <ql/instruments/makeiboroisbasisswap.hpp>
 #include <ql/instruments/makeswaption.hpp>
 #include <ql/instruments/makevanillaswap.hpp>
 #include <ql/instruments/makeyoyinflationcapfloor.hpp>

--- a/QuantLib/ql/instruments/iboroisbasisswap.cpp
+++ b/QuantLib/ql/instruments/iboroisbasisswap.cpp
@@ -1,0 +1,152 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/instruments/iboroisbasisswap.hpp>
+#include <ql/cashflows/overnightindexedcoupon.hpp>
+#include <ql/cashflows/iborcoupon.hpp>
+
+namespace QuantLib {
+
+    IBOROISBasisSwap::IBOROISBasisSwap(
+                    Type type,
+                    Real nominal,
+                    const Schedule& floatingSchedule,
+					const boost::shared_ptr<IborIndex>& iborIndex,
+					const DayCounter& floatingDayCount,
+					const Schedule& overnightSchedule,
+                    const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                    Spread spread,
+					const DayCounter& overnightDayCount,
+					boost::optional<BusinessDayConvention> paymentConvention,
+					bool arithmeticAveragedCoupon)
+    : Swap(2), type_(type), nominals_(std::vector<Real>(1, nominal)),
+	  floatingSchedule_(floatingSchedule), iborIndex_(iborIndex), 
+	  floatingDayCount_(floatingDayCount), overnightSchedule_(overnightSchedule), 
+	  overnightIndex_(overnightIndex), spread_(spread), overnightDayCount_(overnightDayCount),
+	  arithmeticAveragedCoupon_(arithmeticAveragedCoupon){
+
+		  if (paymentConvention)
+            paymentConvention_ = *paymentConvention;
+		  else
+            paymentConvention_ = overnightSchedule_.businessDayConvention();
+
+          initialize();
+
+    }
+
+    IBOROISBasisSwap::IBOROISBasisSwap(
+                    Type type,
+                    std::vector<Real> nominals,
+                    const Schedule& floatingSchedule,
+					const boost::shared_ptr<IborIndex>& iborIndex,
+					const DayCounter& floatingDayCount,
+					const Schedule& overnightSchedule,
+                    const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                    Spread spread,
+					const DayCounter& overnightDayCount,
+					boost::optional<BusinessDayConvention> paymentConvention,
+					bool arithmeticAveragedCoupon)
+    : Swap(2), type_(type), nominals_(nominals),
+      floatingSchedule_(floatingSchedule), iborIndex_(iborIndex), 
+	  floatingDayCount_(floatingDayCount), overnightSchedule_(overnightSchedule), 
+	  overnightIndex_(overnightIndex), spread_(spread), overnightDayCount_(overnightDayCount),
+	  arithmeticAveragedCoupon_(arithmeticAveragedCoupon){
+
+          if (paymentConvention)
+            paymentConvention_ = *paymentConvention;
+		  else
+            paymentConvention_ = floatingSchedule_.businessDayConvention();
+
+          initialize();
+
+    }
+
+    void IBOROISBasisSwap::initialize() {
+		
+        legs_[0] = IborLeg(floatingSchedule_, iborIndex_)
+            .withNotionals(nominals_)
+			.withPaymentDayCounter(floatingDayCount_)
+            .withPaymentAdjustment(paymentConvention_);
+
+        legs_[1] = OvernightLeg(overnightSchedule_, overnightIndex_)
+            .withNotionals(nominals_)
+			.withPaymentDayCounter(overnightDayCount_)
+			.withPaymentAdjustment(paymentConvention_)
+            .withSpreads(spread_);
+		if(arithmeticAveragedCoupon_) {
+			boost::shared_ptr<FloatingRateCouponPricer> arithmeticPricer(
+								new ArithmeticAveragedOvernightIndexedCouponPricer());
+			for(Size i = 0; i < legs_[1].size(); i++) {
+				boost::shared_ptr<OvernightIndexedCoupon> c =
+					boost::dynamic_pointer_cast<OvernightIndexedCoupon> (legs_[1][i]);
+				c->setPricer(arithmeticPricer);
+			}
+		}
+
+        for (Size j=0; j<2; ++j) {
+            for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)
+                registerWith(*i);
+        }
+
+        switch (type_) {
+          case Payer:
+            payer_[0] = -1.0;
+            payer_[1] = +1.0;
+            break;
+          case Receiver:
+            payer_[0] = +1.0;
+            payer_[1] = -1.0;
+            break;
+          default:
+            QL_FAIL("Unknown overnight-basis-swap type");
+        }
+    }
+
+
+    Spread IBOROISBasisSwap::fairSpread() const {
+        static Spread basisPoint = 1.0e-4;
+        calculate();
+        return spread_ - NPV_/(overnightLegBPS()/basisPoint);
+    }
+
+	Real IBOROISBasisSwap::floatingLegBPS() const {
+        calculate();
+        QL_REQUIRE(legBPS_[1] != Null<Real>(), "result not available");
+        return legBPS_[1];
+    }
+
+    Real IBOROISBasisSwap::overnightLegBPS() const {
+        calculate();
+        QL_REQUIRE(legBPS_[1] != Null<Real>(), "result not available");
+        return legBPS_[1];
+    }
+
+    Real IBOROISBasisSwap::floatingLegNPV() const {
+        calculate();
+        QL_REQUIRE(legNPV_[0] != Null<Real>(), "result not available");
+        return legNPV_[0];
+    }
+
+    Real IBOROISBasisSwap::overnightLegNPV() const {
+        calculate();
+        QL_REQUIRE(legNPV_[1] != Null<Real>(), "result not available");
+        return legNPV_[1];
+    }
+
+}

--- a/QuantLib/ql/instruments/iboroisbasisswap.hpp
+++ b/QuantLib/ql/instruments/iboroisbasisswap.hpp
@@ -1,0 +1,126 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file iboroisbasisswap.hpp
+    \brief Overnight index swap paying compounded overnight + spread vs. ibor
+*/
+
+#ifndef quantlib_ibor_ois_basis_swap_hpp
+#define quantlib_ibor_ois_basis_swap_hpp
+
+#include <ql/instruments/swap.hpp>
+#include <ql/time/daycounter.hpp>
+#include <ql/time/schedule.hpp>
+#include <boost/optional.hpp>
+
+
+namespace QuantLib {
+
+	class IborIndex;
+    class OvernightIndex;
+
+    //! Ibor OIS basis swap: ibor vs compounded overnight rate + spread
+    class IBOROISBasisSwap : public Swap {
+      public:
+        enum Type { Receiver = -1, Payer = 1 };
+        IBOROISBasisSwap(
+                    Type type,
+                    Real nominal,
+                    const Schedule& floatSchedule,
+					const boost::shared_ptr<IborIndex>& iborIndex,
+					const DayCounter& floatingDayCount,
+					const Schedule& overnightSchedule,
+                    const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                    Spread spread,
+					const DayCounter& overnightDayCount,
+					boost::optional<BusinessDayConvention> paymentConvention =
+																		boost::none,
+					bool arithmeticAveragedCoupon = true);
+        IBOROISBasisSwap(
+                    Type type,
+                    std::vector<Real> nominals,
+                    const Schedule& floatSchedule,
+					const boost::shared_ptr<IborIndex>& iborIndex,
+					const DayCounter& floatingDayCount,
+					const Schedule& overnightSchedule,
+                    const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                    Spread spread,
+					const DayCounter& overnightDayCount,
+					boost::optional<BusinessDayConvention> paymentConvention =
+																		boost::none,
+					bool arithmeticAveragedCoupon = true);
+        //! \name Inspectors
+        //@{
+        Type type() const { return type_; }
+        Real nominal() const;
+        std::vector<Real> nominals() const { return nominals_; }  
+
+        const Schedule& floatingSchedule() const;
+		const boost::shared_ptr<IborIndex>& iborIndex() const { return iborIndex_; }
+        const DayCounter& floatingDayCount() const;
+
+		const Schedule& overnightSchedule() { return overnightSchedule_; }
+		const boost::shared_ptr<OvernightIndex>& overnightIndex() { return overnightIndex_; }
+        Spread spread() { return spread_; }
+
+		BusinessDayConvention paymentConvention() const { return paymentConvention_; }
+
+        const Leg& floatingLeg() const { return legs_[0]; }
+        const Leg& overnightLeg() const { return legs_[1]; }
+        //@}
+
+        //! \name Results
+        //@{
+        Real floatingLegBPS() const;
+        Real floatingLegNPV() const;
+
+        Real overnightLegBPS() const;
+        Real overnightLegNPV() const;
+        Spread fairSpread() const;
+        //@}
+      private:
+        void initialize();
+        Type type_;
+        std::vector<Real> nominals_;
+
+        Schedule floatingSchedule_;
+        boost::shared_ptr<IborIndex> iborIndex_;
+        DayCounter floatingDayCount_;
+
+		Schedule overnightSchedule_;
+        boost::shared_ptr<OvernightIndex> overnightIndex_;
+        Spread spread_;
+		DayCounter overnightDayCount_;
+
+		BusinessDayConvention paymentConvention_;
+
+		bool arithmeticAveragedCoupon_;
+    };
+
+
+    // inline
+
+    inline Real IBOROISBasisSwap::nominal() const {
+        QL_REQUIRE(nominals_.size()==1, "varying nominals");
+        return nominals_[0];
+    }
+
+}
+
+#endif

--- a/QuantLib/ql/instruments/makeiboroisbasisswap.cpp
+++ b/QuantLib/ql/instruments/makeiboroisbasisswap.cpp
@@ -1,0 +1,250 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/instruments/makeiboroisbasisswap.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/time/schedule.hpp>
+#include <ql/indexes/iborindex.hpp>
+
+namespace QuantLib {
+
+    MakeIBOROISBasisSwap::MakeIBOROISBasisSwap(const Period& swapTenor,
+									   const boost::shared_ptr<IborIndex>& iborIndex,
+									   const boost::shared_ptr<OvernightIndex>& overnightIndex,
+									   Rate spread,
+									   const Period& fwdStart)
+    : swapTenor_(swapTenor), floatingIndex_(iborIndex), overnightIndex_(overnightIndex),
+	  overnightSpread_(spread), forwardStart_(fwdStart), 
+	  type_(IBOROISBasisSwap::Payer), nominal_(1.0), fixingDays_(2),
+	  effectiveDate_(Date()), terminationDate_(Date()),
+	  paymentConvention_(ModifiedFollowing),
+	  endOfMonth_(1*Months<=swapTenor && swapTenor<=2*Years ? true : false),
+	  floatingLegTenor_(iborIndex->tenor()),
+      floatingLegCalendar_(iborIndex->fixingCalendar()),
+      floatingLegConvention_(iborIndex->businessDayConvention()),
+      floatingLegTerminationDateConvention_(iborIndex->businessDayConvention()),
+      floatingLegRule_(DateGeneration::Backward),
+      floatingLegDayCount_(iborIndex->dayCounter()),
+	  overnightLegTenor_(iborIndex->tenor()),//exchange at the end of each ibor period
+      overnightLegCalendar_(overnightIndex->fixingCalendar()),
+      overnightLegConvention_(overnightIndex->businessDayConvention()),
+      overnightLegTerminationDateConvention_(overnightIndex->businessDayConvention()),
+      overnightLegRule_(DateGeneration::Backward),
+      overnightLegDayCount_(overnightIndex->dayCounter()),
+	  engine_(new DiscountingSwapEngine(overnightIndex_->forwardingTermStructure())){}
+
+    MakeIBOROISBasisSwap::operator IBOROISBasisSwap() const {
+        boost::shared_ptr<IBOROISBasisSwap> oisbasis = *this;
+        return *oisbasis;
+    }
+
+    MakeIBOROISBasisSwap::operator boost::shared_ptr<IBOROISBasisSwap>() const {
+
+        const Calendar& calendar = overnightIndex_->fixingCalendar();
+
+        Date startDate;
+        if (effectiveDate_ != Date())
+            startDate = effectiveDate_;
+        else {
+            Date referenceDate = Settings::instance().evaluationDate();
+            Date spotDate = calendar.advance(referenceDate,
+                                             fixingDays_*Days);
+            startDate = spotDate+forwardStart_;
+        }
+
+        Date endDate;
+        if (terminationDate_ != Date()) {
+            endDate = terminationDate_;
+        } else {
+            if (endOfMonth_) {
+                endDate = calendar.advance(startDate, swapTenor_,
+                                           ModifiedFollowing,
+                                           endOfMonth_);
+            } else {
+                endDate = startDate+swapTenor_;
+            }
+        }
+
+        Schedule floatingSchedule(startDate, endDate,
+								  floatingLegTenor_,
+                                  floatingLegCalendar_,
+								  floatingLegConvention_,
+								  floatingLegTerminationDateConvention_,
+								  floatingLegRule_,
+								  endOfMonth_);
+
+		Schedule overnightSchedule(startDate, endDate,
+								   overnightLegTenor_,
+                                   overnightLegCalendar_,
+								   overnightLegConvention_,
+								   overnightLegTerminationDateConvention_,
+								   overnightLegRule_,
+								   endOfMonth_);
+
+        Rate usedOvernightSpread = overnightSpread_;
+        if (overnightSpread_ == Null<Rate>()) {
+            QL_REQUIRE(!overnightIndex_->forwardingTermStructure().empty(),
+                       "null term structure set to this instance of " <<
+                       overnightIndex_->name());
+            IBOROISBasisSwap temp(type_, nominal_,
+                              floatingSchedule,
+							  floatingIndex_,
+							  floatingLegDayCount_,
+							  overnightSchedule,
+							  overnightIndex_,
+                              0.0,
+                              overnightLegDayCount_,
+                              paymentConvention_);
+            // ATM on the forecasting curve
+            bool includeSettlementDateFlows = false;
+            temp.setPricingEngine(boost::shared_ptr<PricingEngine>(
+                new DiscountingSwapEngine(
+                                   overnightIndex_->forwardingTermStructure(),
+                                   includeSettlementDateFlows)));
+            usedOvernightSpread = temp.fairSpread();
+        }
+
+        boost::shared_ptr<IBOROISBasisSwap> oisbasis(new
+            IBOROISBasisSwap(type_, nominal_,
+                              floatingSchedule,
+							  floatingIndex_,
+							  floatingLegDayCount_,
+							  overnightSchedule,
+							  overnightIndex_,
+                              usedOvernightSpread,
+                              overnightLegDayCount_,
+                              paymentConvention_));
+        oisbasis->setPricingEngine(engine_);
+        return oisbasis;
+    }
+
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withType(IBOROISBasisSwap::Type type) {
+        type_ = type;
+        return *this;
+    }
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withNominal(Real n) {
+        nominal_ = n;
+        return *this;
+    }
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withSettlementDays(Natural fixingDays) {
+        fixingDays_ = fixingDays;
+        effectiveDate_ = Date();
+        return *this;
+    }
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withEffectiveDate(const Date& effectiveDate) {
+        effectiveDate_ = effectiveDate;
+        return *this;
+    }
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withTerminationDate(const Date& terminationDate) {
+        terminationDate_ = terminationDate;
+        swapTenor_ = Period();
+        return *this;
+    }
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withPaymentConvention(BusinessDayConvention bdc) {
+		paymentConvention_ = bdc;
+        return *this;
+	}
+
+	MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withEndOfMonth(bool flag) {
+		endOfMonth_ = flag;
+		return *this;
+	}
+
+	MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withFloatingLegTenor(const Period& t) {
+		floatingLegTenor_ = t;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withFloatingLegCalendar(const Calendar& cal) {
+		floatingLegCalendar_ = cal;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withFloatingLegConvention(BusinessDayConvention bdc) {
+		floatingLegConvention_ = bdc;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withFloatingLegTerminationDateConvention(
+                                                BusinessDayConvention bdc) {
+		floatingLegTerminationDateConvention_ = bdc;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withFloatingLegRule(DateGeneration::Rule r) {
+		floatingLegRule_ = r;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withFloatingLegDayCount(const DayCounter& dc) {
+		floatingLegDayCount_ = dc;
+		return *this;
+	}
+
+	MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withOvernightLegTenor(const Period& t) {
+		overnightLegTenor_ = t;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withOvernightLegCalendar(const Calendar& cal) {
+		overnightLegCalendar_ = cal;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withOvernightLegConvention(BusinessDayConvention bdc) {
+		overnightLegConvention_ = bdc;
+		return *this;
+	}
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withOvernightLegTerminationDateConvention(
+                                                BusinessDayConvention bdc) {
+		overnightLegTerminationDateConvention_ = bdc;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withOvernightLegRule(DateGeneration::Rule r) {
+		overnightLegRule_ = r;
+		if (r==DateGeneration::Zero)
+            overnightLegTenor_ = Period(Once);
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withOvernightLegDayCount(const DayCounter& dc) {
+		overnightLegDayCount_ = dc;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withOvernightLegSpread(Spread sp) {
+		overnightSpread_ = sp;
+		return *this;
+	}
+
+    MakeIBOROISBasisSwap& MakeIBOROISBasisSwap::withDiscountingTermStructure(
+                const Handle<YieldTermStructure>& discountingTermStructure) {
+		engine_ = boost::shared_ptr<PricingEngine>(new
+                            DiscountingSwapEngine(discountingTermStructure));
+        return *this;
+	}
+
+}

--- a/QuantLib/ql/instruments/makeiboroisbasisswap.hpp
+++ b/QuantLib/ql/instruments/makeiboroisbasisswap.hpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file makeiboroisbasisSwap.hpp
+    \brief Helper class to instantiate ibor vs. overnight indexed swaps.
+*/
+
+#ifndef quantlib_makeiboroisbasisswap_hpp
+#define quantlib_makeiboroisbasisswap_hpp
+
+#include <ql/instruments/iboroisbasisswap.hpp>
+#include <ql/time/dategenerationrule.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+
+namespace QuantLib {
+
+    //! helper class
+    /*! This class provides a more comfortable way
+        to instantiate ibor vs. overnight indexed swaps.
+    */
+    class MakeIBOROISBasisSwap {
+      public:
+        MakeIBOROISBasisSwap(const Period& swapTenor,
+				const boost::shared_ptr<IborIndex>& iborIndex,
+                const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                Rate spread = Null<Rate>(),
+                const Period& fwdStart = 0*Days);
+
+        operator IBOROISBasisSwap() const;
+        operator boost::shared_ptr<IBOROISBasisSwap>() const ;
+
+        MakeIBOROISBasisSwap& withType(IBOROISBasisSwap::Type type);
+        MakeIBOROISBasisSwap& withNominal(Real n);
+        MakeIBOROISBasisSwap& withSettlementDays(Natural fixingDays);
+        MakeIBOROISBasisSwap& withEffectiveDate(const Date&);
+        MakeIBOROISBasisSwap& withTerminationDate(const Date&);
+		MakeIBOROISBasisSwap& withEndOfMonth(bool flag = true);
+        MakeIBOROISBasisSwap& withPaymentConvention(BusinessDayConvention bc);
+
+        MakeIBOROISBasisSwap& withFloatingLegTenor(const Period& t);
+        MakeIBOROISBasisSwap& withFloatingLegCalendar(const Calendar& cal);
+        MakeIBOROISBasisSwap& withFloatingLegConvention(BusinessDayConvention bdc);
+        MakeIBOROISBasisSwap& withFloatingLegTerminationDateConvention(
+                                                   BusinessDayConvention bdc);
+        MakeIBOROISBasisSwap& withFloatingLegRule(DateGeneration::Rule r);
+        MakeIBOROISBasisSwap& withFloatingLegDayCount(const DayCounter& dc);
+
+		MakeIBOROISBasisSwap& withOvernightLegTenor(const Period& t);
+        MakeIBOROISBasisSwap& withOvernightLegCalendar(const Calendar& cal);
+        MakeIBOROISBasisSwap& withOvernightLegConvention(BusinessDayConvention bdc);
+        MakeIBOROISBasisSwap& withOvernightLegTerminationDateConvention(
+                                                   BusinessDayConvention bdc);
+        MakeIBOROISBasisSwap& withOvernightLegRule(DateGeneration::Rule r);
+        MakeIBOROISBasisSwap& withOvernightLegDayCount(const DayCounter& dc);
+        MakeIBOROISBasisSwap& withOvernightLegSpread(Spread sp);
+
+        MakeIBOROISBasisSwap& withDiscountingTermStructure(
+                  const Handle<YieldTermStructure>& discountingTermStructure);
+
+      private:
+        Period swapTenor_;
+		boost::shared_ptr<IborIndex> floatingIndex_;
+		boost::shared_ptr<OvernightIndex> overnightIndex_;
+		Spread overnightSpread_;
+		Period forwardStart_;
+		bool endOfMonth_;
+
+		IBOROISBasisSwap::Type type_;
+        Real nominal_;
+		Natural fixingDays_;
+		Date effectiveDate_, terminationDate_;
+		BusinessDayConvention paymentConvention_;
+
+        Period floatingLegTenor_;
+        Calendar floatingLegCalendar_;
+        BusinessDayConvention floatingLegConvention_;
+        BusinessDayConvention floatingLegTerminationDateConvention_;
+        DateGeneration::Rule floatingLegRule_;      
+        DayCounter floatingLegDayCount_;
+
+		Period overnightLegTenor_;
+        Calendar overnightLegCalendar_;
+        BusinessDayConvention overnightLegConvention_;
+        BusinessDayConvention overnightLegTerminationDateConvention_;
+        DateGeneration::Rule overnightLegRule_;
+        DayCounter overnightLegDayCount_;
+
+        boost::shared_ptr<PricingEngine> engine_;
+    };
+
+}
+
+#endif

--- a/QuantLib/ql/termstructures/all.hpp
+++ b/QuantLib/ql/termstructures/all.hpp
@@ -8,6 +8,7 @@
 #include <ql/termstructures/interpolatedcurve.hpp>
 #include <ql/termstructures/iterativebootstrap.hpp>
 #include <ql/termstructures/localbootstrap.hpp>
+#include <ql/termstructures/multibootstrap.hpp>
 #include <ql/termstructures/voltermstructure.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
 

--- a/QuantLib/ql/termstructures/multibootstrap.hpp
+++ b/QuantLib/ql/termstructures/multibootstrap.hpp
@@ -1,0 +1,331 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2013 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file multibootstrap.hpp
+    \brief multiple bootstrapper for simultanaous bootstrap of multiple curves.
+*/
+
+#ifndef quantlib_multi_bootstrap_hpp
+#define quantlib_multi_bootstrap_hpp
+
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/bootstraphelper.hpp>
+#include <ql/math/optimization/costfunction.hpp>
+#include <ql/math/optimization/constraint.hpp>
+#include <ql/math/optimization/armijo.hpp>
+#include <ql/math/optimization/levenbergmarquardt.hpp>
+#include <ql/math/optimization/leastsquare.hpp>
+#include <ql/math/optimization/problem.hpp>
+#include <ql/utilities/dataformatters.hpp>
+#include <ql/termstructures/iterativebootstrap.hpp>
+#include <ql/patterns/lazyobject.hpp>
+#include <boost/shared_ptr.hpp>
+
+namespace QuantLib {
+
+	// penalty function class for multiple curve
+    template <class Curve>
+    class MultiCurvePenaltyFunction : public CostFunction {
+	public:
+        typedef typename Curve::traits_type Traits;
+        typedef typename Traits::helper helper;
+        typedef
+          typename std::vector< boost::shared_ptr<helper> >::const_iterator helper_iterator;
+      
+        MultiCurvePenaltyFunction(std::vector<Curve*> curves,
+								  std::vector<Size> initialIndexes,
+								  std::vector<helper_iterator> rateHelpersStarts,
+								  std::vector<helper_iterator> rateHelpersEnds)
+        : curves_(curves), initialIndexes_(initialIndexes),
+          rateHelpersStarts_(rateHelpersStarts), rateHelpersEnds_(rateHelpersEnds) {
+        }
+
+        Real value(const Array& x) const;
+        Disposable<Array> values(const Array& x) const;
+
+      private:
+        std::vector<Curve*> curves_;
+        std::vector<Size> initialIndexes_;
+        std::vector<helper_iterator> rateHelpersStarts_;
+        std::vector<helper_iterator> rateHelpersEnds_;
+    };
+
+
+	template <class Curve>
+	class MultiCurveOptimizer : public LazyObject {
+	  public:
+	    MultiCurveOptimizer(bool forcePositive = true) 
+		: accuracy_(1.0e-12), forcePositive_(forcePositive){};
+		void addTermStructure(Curve* c) {
+			for (Size i=0; i<c->instruments_.size(); ++i){
+				this->registerWith(c->instruments_[i]);
+			}
+			ts_.push_back(c);
+			accuracy_ = accuracy_ > c->accuracy_ ? c->accuracy_ : accuracy_;
+		};
+		void optimize() const { calculate(); };
+		//! \name Observer interface
+        //@{
+		void update();
+        //@}
+	  private:
+		//! \name LazyObject interface
+        //@{
+        void performCalculations() const;
+        //@}
+		Real accuracy_;
+		bool forcePositive_;
+		std::vector<Curve*> ts_;
+	};
+
+	template <class Curve>
+	void MultiCurveOptimizer<Curve>::update() {
+		LazyObject::update();
+	}
+
+	template <class Curve>
+	void MultiCurveOptimizer<Curve>::performCalculations() const {
+
+        std::vector<Size> initialIndexes;
+        std::vector< typename MultiCurvePenaltyFunction<Curve>::helper_iterator > rateHelpersStarts;
+        std::vector< typename MultiCurvePenaltyFunction<Curve>::helper_iterator > rateHelpersEnds;
+
+		Size nInsts = 0;
+		for(Size i = 0; i < ts_.size(); i++) {
+			ts_[i]->bootstrap_.initialize();
+			nInsts += ts_[i]->instruments_.size();
+			initialIndexes.push_back(1);
+			rateHelpersStarts.push_back(ts_[i]->instruments_.begin());
+			rateHelpersEnds.push_back(ts_[i]->instruments_.end());
+		}
+
+        LevenbergMarquardt solver(accuracy_,
+                                  accuracy_,
+                                  accuracy_);
+		
+        EndCriteria endCriteria(20*nInsts, 10, 0.00, accuracy_, 0.00);
+        PositiveConstraint posConstraint;
+        NoConstraint noConstraint;
+        Constraint& solverConstraint = forcePositive_ ?
+            static_cast<Constraint&>(posConstraint) :
+            static_cast<Constraint&>(noConstraint);
+
+		Array startArray(nInsts);
+
+		Size pos = 0;
+		for(Size i = 0; i < ts_.size(); i++) {
+			for (Size j = 0; j < ts_[i]->instruments_.size(); j++) {
+				startArray[pos] = ts_[i]->data_[j + initialIndexes[i]];
+				pos ++;
+			}
+		}
+
+		MultiCurvePenaltyFunction<Curve> currentCost(
+                    ts_,
+                    initialIndexes,
+                    rateHelpersStarts,
+                    rateHelpersEnds);
+
+        Problem toSolve(currentCost, solverConstraint, startArray);
+
+        EndCriteria::Type endType = solver.minimize(toSolve, endCriteria);
+
+        // check the end criteria
+        QL_REQUIRE(endType == EndCriteria::StationaryFunctionAccuracy ||
+                    endType == EndCriteria::StationaryFunctionValue,
+                    "Unable to strip yieldcurve to required accuracy " );
+
+		
+	}
+
+    //! multiple bootstrapper for simultanaous bootstrap of multiple curves.
+    /*! 
+		\TODO: template <class Curve> should be unique for all curves.
+    */
+    template <class Curve>
+    class MultiBootstrap {
+        typedef typename Curve::traits_type Traits;
+        typedef typename Curve::interpolator_type Interpolator;
+      public:
+
+        MultiBootstrap(boost::shared_ptr<MultiCurveOptimizer<Curve> > optimizer = 
+										boost::shared_ptr<MultiCurveOptimizer<Curve> >(new MultiCurveOptimizer<Curve>() ));
+        void setup(Curve* ts);
+        void calculate() const;
+
+      private:
+        friend MultiCurveOptimizer<Curve>;
+		void initialize() const;
+        mutable bool validCurve_;
+        Curve* ts_;
+		boost::shared_ptr<MultiCurveOptimizer<Curve> > multiCurveOptimizer_;
+    };
+
+
+    // template definitions
+
+    template <class Curve>
+    MultiBootstrap<Curve>::MultiBootstrap(boost::shared_ptr<MultiCurveOptimizer<Curve> > optimizer)
+    : ts_(0), validCurve_(false), multiCurveOptimizer_(optimizer)
+    {}
+
+    template <class Curve>
+    void MultiBootstrap<Curve>::setup(Curve* ts) {
+
+        ts_ = ts;
+
+        Size n = ts_->instruments_.size();
+        QL_REQUIRE(n >= Interpolator::requiredPoints,
+                   "not enough instruments: " << n << " provided, " <<
+                   Interpolator::requiredPoints << " required");
+
+        for (Size i=0; i<n; ++i){
+            ts_->registerWith(ts_->instruments_[i]);
+        }
+
+		multiCurveOptimizer_->addTermStructure(ts_);
+    
+    }
+
+    template <class Curve>
+    void MultiBootstrap<Curve>::initialize() const {
+   
+        Size nInsts = ts_->instruments_.size();
+
+        // ensure rate helpers are sorted
+        std::sort(ts_->instruments_.begin(), ts_->instruments_.end(),
+                  detail::BootstrapHelperSorter());
+
+        // check that there is no instruments with the same maturity
+        for (Size i=1; i<nInsts; ++i) {
+            Date m1 = ts_->instruments_[i-1]->latestDate(),
+                 m2 = ts_->instruments_[i]->latestDate();
+            QL_REQUIRE(m1 != m2,
+                       "two instruments have the same maturity ("<< m1 <<")");
+        }
+
+        // check that there is no instruments with invalid quote
+        for (Size i=0; i<nInsts; ++i)
+            QL_REQUIRE(ts_->instruments_[i]->quote()->isValid(),
+                       io::ordinal(i+1) << " instrument (maturity: " <<
+                       ts_->instruments_[i]->latestDate() <<
+                       ") has an invalid quote");
+
+        // setup instruments
+        for (Size i=0; i<nInsts; ++i) {
+            // don't try this at home!
+            // This call creates instruments, and removes "const".
+            // There is a significant interaction with observability.
+            ts_->instruments_[i]->setTermStructure(const_cast<Curve*>(ts_));
+        }
+        // set initial guess only if the current curve cannot be used as guess
+        if (validCurve_)
+            QL_ENSURE(ts_->data_.size() == nInsts+1,
+                      "dimension mismatch: expected " << nInsts+1 <<
+                      ", actual " << ts_->data_.size());
+        else {
+            ts_->data_ = std::vector<Rate>(nInsts+1);
+            ts_->data_[0] = Traits::initialValue(ts_);
+        }
+
+        // calculate dates and times
+        ts_->dates_ = std::vector<Date>(nInsts+1);
+        ts_->times_ = std::vector<Time>(nInsts+1);
+        ts_->dates_[0] = Traits::initialDate(ts_);
+        ts_->times_[0] = ts_->timeFromReference(ts_->dates_[0]);
+        for (Size i=0; i<nInsts; ++i) {
+            ts_->dates_[i+1] = ts_->instruments_[i]->latestDate();
+            ts_->times_[i+1] = ts_->timeFromReference(ts_->dates_[i+1]);
+            if (!validCurve_)
+                ts_->data_[i+1] = ts_->data_[i];
+        }
+
+		ts_->interpolation_ =
+            ts_->interpolator_.interpolate(ts_->times_.begin(),
+                                            ts_->times_.end(),
+                                            ts_->data_.begin());
+
+        
+    }
+
+	template <class Curve>
+    void MultiBootstrap<Curve>::calculate() const {
+		validCurve_ = false;
+		multiCurveOptimizer_->optimize();
+		validCurve_ = true;
+    
+	}
+
+    template <class Curve>
+    Real MultiCurvePenaltyFunction<Curve>::value(const Array& x) const {
+		Array::const_iterator guessIt = x.begin();
+		for(Size n = 0; n < curves_.size(); n++) {
+			Size nInsts = curves_[n]->instruments_.size();
+			Size i = initialIndexes_[n];
+			for(Size j = 0; j < nInsts; j++) {
+				Traits::updateGuess(curves_[n]->data_, *guessIt, j+i);
+				++guessIt;
+			}
+			curves_[n]->interpolation_.update();
+		} 
+
+        Real penalty = 0.0;
+		for(Size n = 0; n < curves_.size(); n++) {
+			helper_iterator instIt = rateHelpersStarts_[n];
+			while (instIt != rateHelpersEnds_[n]) {
+				Real quoteError = (*instIt)->quoteError();
+				penalty += std::fabs(quoteError);
+				++instIt;
+			}
+		}
+        return penalty;
+    }
+
+    template <class Curve>
+    Disposable<Array> MultiCurvePenaltyFunction<Curve>::values(const Array& x) const {
+		Array::const_iterator guessIt = x.begin();
+		for(Size n = 0; n < curves_.size(); n++) {
+			Size nInsts = curves_[n]->instruments_.size();
+			Size i = initialIndexes_[n];
+			for(Size j = 0; j < nInsts; j++) {
+				Traits::updateGuess(curves_[n]->data_, *guessIt, j + i);
+				++guessIt;
+			}
+			curves_[n]->interpolation_.update();
+		}
+
+        Array penalties(x.size());
+		Array::iterator penIt = penalties.begin();
+		for(Size n = 0; n < curves_.size(); n++) {
+			helper_iterator instIt = rateHelpersStarts_[n];
+			while (instIt != rateHelpersEnds_[n]) {
+				Real quoteError = (*instIt)->quoteError();
+				*penIt = std::fabs(quoteError);
+				++instIt;
+				++penIt;
+			}
+		}
+        return penalties;
+    }
+
+  
+
+}
+
+#endif

--- a/QuantLib/ql/termstructures/yield/Makefile.am
+++ b/QuantLib/ql/termstructures/yield/Makefile.am
@@ -16,6 +16,7 @@ this_include_HEADERS = \
     impliedtermstructure.hpp \
     nonlinearfittingmethods.hpp \
     oisratehelper.hpp \
+    oisbasisratehelper.hpp \
     piecewiseyieldcurve.hpp \
     piecewisezerospreadedtermstructure.hpp \
     quantotermstructure.hpp \
@@ -31,6 +32,7 @@ libYieldTermStructures_la_SOURCES = \
     forwardstructure.cpp \
     nonlinearfittingmethods.cpp \
     oisratehelper.cpp \
+    oisbasisratehelper.cpp \
     ratehelpers.cpp \
     zeroyieldstructure.cpp
 

--- a/QuantLib/ql/termstructures/yield/all.hpp
+++ b/QuantLib/ql/termstructures/yield/all.hpp
@@ -13,6 +13,7 @@
 #include <ql/termstructures/yield/impliedtermstructure.hpp>
 #include <ql/termstructures/yield/nonlinearfittingmethods.hpp>
 #include <ql/termstructures/yield/oisratehelper.hpp>
+#include <ql/termstructures/yield/oisbasisratehelper.hpp>
 #include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
 #include <ql/termstructures/yield/piecewisezerospreadedtermstructure.hpp>
 #include <ql/termstructures/yield/quantotermstructure.hpp>

--- a/QuantLib/ql/termstructures/yield/oisbasisratehelper.cpp
+++ b/QuantLib/ql/termstructures/yield/oisbasisratehelper.cpp
@@ -1,0 +1,214 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/termstructures/yield/oisbasisratehelper.hpp>
+#include <ql/instruments/makeiboroisbasisswap.hpp>
+#include <ql/instruments/makeois.hpp>
+#include <ql/instruments/makevanillaswap.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/cashflows/overnightindexedcoupon.hpp>
+
+using boost::shared_ptr;
+
+namespace QuantLib {
+
+    namespace {
+        void no_deletion(YieldTermStructure*) {}
+    }
+
+    IBOROISBasisRateHelper::IBOROISBasisRateHelper(
+						  Natural settlementDays,
+						  const Period& tenor,
+						  const Handle<Quote>& overnightSpread,
+						  const boost::shared_ptr<IborIndex>& iborIndex,
+						  const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                          const Handle<YieldTermStructure>& discount)
+    : RelativeDateRateHelper(overnightSpread),
+      settlementDays_(settlementDays), tenor_(tenor),
+	  iborIndex_(iborIndex), overnightIndex_(overnightIndex), 
+	  discountHandle_(discount) {
+		registerWith(iborIndex_);
+        registerWith(overnightIndex_);
+        registerWith(discountHandle_);
+        initializeDates();
+    }
+
+    void IBOROISBasisRateHelper::initializeDates() {
+
+        // dummy OvernightIndex with curve/swap arguments
+        // review here
+        boost::shared_ptr<IborIndex> tempClonedIborIndex =
+            overnightIndex_->clone(termStructureHandle_);
+        shared_ptr<OvernightIndex> clonedOvernightIndex =
+            boost::dynamic_pointer_cast<OvernightIndex>(tempClonedIborIndex);
+
+        // input discount curve Handle might be empty now but it could
+        //    be assigned a curve later; use a RelinkableHandle here
+        swap_ = MakeIBOROISBasisSwap(tenor_, iborIndex_, clonedOvernightIndex, 0.0)
+            .withDiscountingTermStructure(discountRelinkableHandle_)
+            .withSettlementDays(settlementDays_);
+
+        earliestDate_ = swap_->startDate();
+        latestDate_ = swap_->maturityDate();
+    }
+
+    void IBOROISBasisRateHelper::setTermStructure(YieldTermStructure* t) {
+        // do not set the relinkable handle as an observer -
+        // force recalculation when needed
+        bool observer = false;
+
+        shared_ptr<YieldTermStructure> temp(t, no_deletion);
+        termStructureHandle_.linkTo(temp, observer);
+
+        if (discountHandle_.empty())
+            discountRelinkableHandle_.linkTo(temp, observer);
+        else
+            discountRelinkableHandle_.linkTo(*discountHandle_, observer);
+
+        RelativeDateRateHelper::setTermStructure(t);
+    }
+
+    Real IBOROISBasisRateHelper::impliedQuote() const {
+        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        // we didn't register as observers - force calculation
+        swap_->recalculate();
+        return swap_->fairSpread();
+    }
+
+    void IBOROISBasisRateHelper::accept(AcyclicVisitor& v) {
+        Visitor<IBOROISBasisRateHelper>* v1 =
+            dynamic_cast<Visitor<IBOROISBasisRateHelper>*>(&v);
+        if (v1 != 0)
+            v1->visit(*this);
+        else
+            RateHelper::accept(v);
+    }
+
+	
+	FixedOISBasisRateHelper::FixedOISBasisRateHelper(
+                    Natural settlementDays,
+					const Period& tenor, // swap maturity
+					const Handle<Quote>& overnightSpread,
+					const Handle<Quote>& fixedRate,
+					Frequency fixedFrequency,
+                    BusinessDayConvention fixedConvention,
+                    const DayCounter& fixedDayCount,
+					const boost::shared_ptr<OvernightIndex>& overnightIndex,
+					Frequency overnightFrequency,
+                    const Handle<YieldTermStructure>& discount)
+    : RelativeDateRateHelper(overnightSpread), fixedRate_(fixedRate),
+	  usedFixedRate_(fixedRate->value()), fixedFrequency_(fixedFrequency),
+	  fixedConvention_(fixedConvention), fixedDayCount_(fixedDayCount),
+      settlementDays_(settlementDays), tenor_(tenor),
+      overnightIndex_(overnightIndex), overnightFrequency_(overnightFrequency),
+	  discountHandle_(discount) {
+		registerWith(fixedRate);
+        registerWith(overnightIndex_);
+        registerWith(discountHandle_);
+        initializeDates();
+    }
+
+    void FixedOISBasisRateHelper::initializeDates() {
+
+        // dummy OvernightIndex with curve/swap arguments
+        // review here
+        boost::shared_ptr<IborIndex> clonedIborIndex =
+            overnightIndex_->clone(termStructureHandle_);
+        shared_ptr<OvernightIndex> clonedOvernightIndex =
+            boost::dynamic_pointer_cast<OvernightIndex>(clonedIborIndex);
+
+        // input discount curve Handle might be empty now but it could
+        //    be assigned a curve later; use a RelinkableHandle here
+		boost::shared_ptr<IborIndex> dummyIndex(new IborIndex("Dummy", 
+															  Period(overnightFrequency_),
+															  settlementDays_, 
+															  clonedIborIndex->currency(),
+															  clonedIborIndex->fixingCalendar(),
+															  clonedIborIndex->businessDayConvention(),
+															  clonedIborIndex->endOfMonth(),
+															  clonedIborIndex->dayCounter()));
+		boost::shared_ptr<VanillaSwap> dummyVanillaSwap = 
+						MakeVanillaSwap(tenor_, dummyIndex, usedFixedRate_)
+									.withFixedLegDayCount(fixedDayCount_)
+									.withFixedLegTenor(Period(fixedFrequency_))
+									.withFixedLegConvention(fixedConvention_)
+									.withFixedLegTerminationDateConvention(fixedConvention_);
+        boost::shared_ptr<OvernightIndexedSwap> dummyOISSwap = 
+						MakeOIS(tenor_, clonedOvernightIndex, usedFixedRate_)
+						.withSettlementDays(settlementDays_)
+						.withPaymentFrequency(overnightFrequency_);
+		Leg oisBasisLeg = dummyOISSwap->overnightLeg();
+
+		boost::shared_ptr<FloatingRateCouponPricer> arithmeticPricer(
+									new ArithmeticAveragedOvernightIndexedCouponPricer());
+		for(Size i = 0; i < oisBasisLeg.size(); i++) {
+			boost::shared_ptr<OvernightIndexedCoupon> c =
+				boost::dynamic_pointer_cast<OvernightIndexedCoupon> (oisBasisLeg[i]);
+			c->setPricer(arithmeticPricer);
+		}
+
+		swap_ = boost::shared_ptr<Swap>(new Swap(dummyVanillaSwap->fixedLeg(), dummyOISSwap->overnightLeg()));
+		boost::shared_ptr<PricingEngine> engine(new DiscountingSwapEngine(discountRelinkableHandle_));
+		swap_->setPricingEngine(engine);
+
+        earliestDate_ = swap_->startDate();
+        latestDate_ = swap_->maturityDate();
+    }
+
+    void FixedOISBasisRateHelper::setTermStructure(YieldTermStructure* t) {
+        // do not set the relinkable handle as an observer -
+        // force recalculation when needed
+        bool observer = false;
+
+        shared_ptr<YieldTermStructure> temp(t, no_deletion);
+        termStructureHandle_.linkTo(temp, observer);
+
+        if (discountHandle_.empty())
+            discountRelinkableHandle_.linkTo(temp, observer);
+        else
+            discountRelinkableHandle_.linkTo(*discountHandle_, observer);
+
+        RelativeDateRateHelper::setTermStructure(t);
+    }
+
+    Real FixedOISBasisRateHelper::impliedQuote() const {
+        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        // we didn't register as observers - force calculation
+        swap_->recalculate();
+        return - swap_->NPV()/(swap_->legBPS(1)/1.0e-4);
+    }
+
+    void FixedOISBasisRateHelper::accept(AcyclicVisitor& v) {
+        Visitor<FixedOISBasisRateHelper>* v1 =
+            dynamic_cast<Visitor<FixedOISBasisRateHelper>*>(&v);
+        if (v1 != 0)
+            v1->visit(*this);
+        else
+            RateHelper::accept(v);
+    }
+
+	void FixedOISBasisRateHelper::update() {
+		if (usedFixedRate_ != fixedRate_->value()) {
+			usedFixedRate_ = fixedRate_->value();
+			initializeDates(); 
+		}
+		RelativeDateRateHelper::update();
+	}
+
+}

--- a/QuantLib/ql/termstructures/yield/oisbasisratehelper.hpp
+++ b/QuantLib/ql/termstructures/yield/oisbasisratehelper.hpp
@@ -1,0 +1,125 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file oisbasisratehelper.hpp
+    \brief ibor vs. Overnight Indexed basis Swap rate helpers
+*/
+
+#ifndef quantlib_oisbasisratehelper_hpp
+#define quantlib_oisbasisratehelper_hpp
+
+#include <ql/termstructures/yield/ratehelpers.hpp>
+#include <ql/instruments/iboroisbasisswap.hpp>
+#include <ql/instruments/overnightindexedswap.hpp>
+
+namespace QuantLib {
+
+    //! Rate helper for bootstrapping over Ibor vs. Overnight Indexed basis Swap rates
+    class IBOROISBasisRateHelper : public RelativeDateRateHelper {
+      public:
+        IBOROISBasisRateHelper(Natural settlementDays,
+						  const Period& tenor, // swap maturity
+						  const Handle<Quote>& overnightSpread,
+						  const boost::shared_ptr<IborIndex>& iborIndex,
+						  const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                          // exogenous discounting curve
+                          const Handle<YieldTermStructure>& discountingCurve
+                                            = Handle<YieldTermStructure>());
+        //! \name RateHelper interface
+        //@{
+        Real impliedQuote() const;
+        void setTermStructure(YieldTermStructure*);
+        //@}
+        //! \name inspectors
+        //@{
+        boost::shared_ptr<IBOROISBasisSwap> swap() const { return swap_; }
+        //@}
+        //! \name Visitability
+        //@{
+        void accept(AcyclicVisitor&);
+        //@}
+    protected:
+        void initializeDates();
+
+        Natural settlementDays_;
+        Period tenor_;
+		boost::shared_ptr<IborIndex> iborIndex_;
+        boost::shared_ptr<OvernightIndex> overnightIndex_;
+
+        boost::shared_ptr<IBOROISBasisSwap> swap_;
+        RelinkableHandle<YieldTermStructure> termStructureHandle_;
+
+        Handle<YieldTermStructure> discountHandle_;
+        RelinkableHandle<YieldTermStructure> discountRelinkableHandle_;
+    };
+
+	//! Rate helper for bootstrapping over Fixed vs. Overnight Indexed basis Swap rates
+    class FixedOISBasisRateHelper : public RelativeDateRateHelper {
+      public:
+        FixedOISBasisRateHelper(Natural settlementDays,
+						  const Period& tenor, // swap maturity
+						  const Handle<Quote>& overnightSpread,
+						  const Handle<Quote>& fixedRate,
+						  Frequency fixedFrequency,
+                          BusinessDayConvention fixedConvention,
+                          const DayCounter& fixedDayCount,
+						  const boost::shared_ptr<OvernightIndex>& overnightIndex,
+						  Frequency overnightFrequency, 
+                          // exogenous discounting curve
+                          const Handle<YieldTermStructure>& discountingCurve
+                                            = Handle<YieldTermStructure>());
+        //! \name RateHelper interface
+        //@{
+        Real impliedQuote() const;
+        void setTermStructure(YieldTermStructure*);
+        //@}
+        //! \name inspectors
+        //@{
+        boost::shared_ptr<Swap> swap() const { return swap_; }
+        //@}
+        //! \name Visitability
+        //@{
+        void accept(AcyclicVisitor&);
+        //@}
+		//! \name Observer interface
+        //@{
+        void update();
+        //@}
+    protected:
+        void initializeDates();
+
+        Natural settlementDays_;
+        Period tenor_;
+		Handle<Quote> fixedRate_;
+		Real usedFixedRate_;
+		Frequency fixedFrequency_;
+        BusinessDayConvention fixedConvention_;
+        DayCounter fixedDayCount_;
+        boost::shared_ptr<OvernightIndex> overnightIndex_;
+		Frequency overnightFrequency_;
+
+        boost::shared_ptr<Swap> swap_;
+        RelinkableHandle<YieldTermStructure> termStructureHandle_;
+
+        Handle<YieldTermStructure> discountHandle_;
+        RelinkableHandle<YieldTermStructure> discountRelinkableHandle_;
+    };
+}
+
+#endif

--- a/QuantLib/ql/termstructures/yield/piecewiseyieldcurve.hpp
+++ b/QuantLib/ql/termstructures/yield/piecewiseyieldcurve.hpp
@@ -28,6 +28,7 @@
 
 #include <ql/termstructures/iterativebootstrap.hpp>
 #include <ql/termstructures/localbootstrap.hpp>
+#include <ql/termstructures/multibootstrap.hpp>
 #include <ql/termstructures/yield/bootstraptraits.hpp>
 #include <ql/patterns/lazyobject.hpp>
 
@@ -189,6 +190,8 @@ namespace QuantLib {
         friend class Bootstrap<this_curve>;
         friend class BootstrapError<this_curve> ;
         friend class PenaltyFunction<this_curve>;
+        friend class MultiCurvePenaltyFunction<this_curve>;
+        friend class MultiCurveOptimizer<this_curve>;
         Bootstrap<this_curve> bootstrap_;
     };
 

--- a/QuantLib/test-suite/Makefile.am
+++ b/QuantLib/test-suite/Makefile.am
@@ -107,6 +107,7 @@ QL_TESTS = \
 	sampledcurve.hpp sampledcurve.cpp \
 	schedule.hpp schedule.cpp \
 	shortratemodels.hpp shortratemodels.cpp \
+	simultaneouscurvebootstrap.hpp simultaneouscurvebootstrap.cpp \
 	solvers.hpp solvers.cpp \
 	spreadoption.hpp spreadoption.cpp \
 	stats.hpp stats.cpp \

--- a/QuantLib/test-suite/quantlibtestsuite.cpp
+++ b/QuantLib/test-suite/quantlibtestsuite.cpp
@@ -147,6 +147,7 @@
 #include "sampledcurve.hpp"
 #include "schedule.hpp"
 #include "shortratemodels.hpp"
+#include "simultaneouscurvebootstrap.hpp"
 #include "solvers.hpp"
 #include "spreadoption.hpp"
 #include "swingoption.hpp"
@@ -334,6 +335,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(SampledCurveTest::suite());
     test->add(ScheduleTest::suite());
     test->add(ShortRateModelTest::suite()); // fails with QL_USE_INDEXED_COUPON
+    test->add(SimultaneousBootstrapTest::suite());
     test->add(Solver1DTest::suite());
     test->add(StatisticsTest::suite());
     test->add(SwapTest::suite());

--- a/QuantLib/test-suite/simultaneouscurvebootstrap.cpp
+++ b/QuantLib/test-suite/simultaneouscurvebootstrap.cpp
@@ -1,0 +1,654 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "simultaneouscurvebootstrap.hpp"
+#include "utilities.hpp"
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/multibootstrap.hpp>
+#include <ql/termstructures/yield/ratehelpers.hpp>
+#include <ql/termstructures/yield/oisratehelper.hpp>
+#include <ql/termstructures/yield/oisbasisratehelper.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/indexes/iborindex.hpp>
+#include <ql/indexes/ibor/eonia.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/indexes/ibor/usdlibor.hpp>
+#include <ql/currencies/america.hpp>
+#include <ql/math/interpolations/linearinterpolation.hpp>
+#include <ql/math/interpolations/loginterpolation.hpp>
+#include <ql/math/interpolations/backwardflatinterpolation.hpp>
+#include <ql/math/interpolations/cubicinterpolation.hpp>
+#include <ql/math/interpolations/convexmonotoneinterpolation.hpp>
+#include <ql/math/comparison.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/utilities/dataformatters.hpp>
+#include <ql/pricingengines/bond/discountingbondengine.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <iomanip>
+#include <iostream>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+void SimultaneousBootstrapTest::testDependentCurveBootstrapConsistency() {
+	BOOST_MESSAGE(
+        "Testing consistency of independent curves bootstrap in simultaneous curve bootstrap framework...");
+
+	SavedSettings backup;
+
+	Settings::instance().evaluationDate() = Date(23, Oct, 2014);
+	boost::shared_ptr<IborIndex> euribor(new Euribor(6*Months));
+	boost::shared_ptr<OvernightIndex> eonia(new Eonia());
+	//optimizer for simultaneous bootstrap
+	boost::shared_ptr<MultiCurveOptimizer<PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap> > > 
+					optimizer(new MultiCurveOptimizer<PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap> >(false));
+
+	//ois curve
+	std::vector<boost::shared_ptr<RateHelper> > insts_ois;
+	std::vector<Date> oisDates;
+	//ois quote
+	Handle<Quote> o1(boost::shared_ptr<Quote>(new SimpleQuote(-0.000218)));//1y
+	Handle<Quote> o2(boost::shared_ptr<Quote>(new SimpleQuote(-0.000222)));//2y
+	Handle<Quote> o3(boost::shared_ptr<Quote>(new SimpleQuote( 0.000135)));//3y
+	Handle<Quote> o4(boost::shared_ptr<Quote>(new SimpleQuote( 0.000799)));//4y
+	Handle<Quote> o5(boost::shared_ptr<Quote>(new SimpleQuote( 0.001715)));//5y
+	Handle<Quote> o6(boost::shared_ptr<Quote>(new SimpleQuote( 0.004082)));//7y
+	Handle<Quote> o7(boost::shared_ptr<Quote>(new SimpleQuote( 0.007879)));//10y
+	Handle<Quote> o8(boost::shared_ptr<Quote>(new SimpleQuote( 0.011333)));//15y
+	Handle<Quote> o9(boost::shared_ptr<Quote>(new SimpleQuote( 0.01247)));//20y
+	Handle<Quote> o10(boost::shared_ptr<Quote>(new SimpleQuote(0.01347)));//30y
+
+	boost::shared_ptr<RateHelper> oh1(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 1*Years, o1, eonia)));
+	boost::shared_ptr<RateHelper> oh2(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 2*Years, o2, eonia)));
+	boost::shared_ptr<RateHelper> oh3(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 3*Years, o3, eonia)));
+	boost::shared_ptr<RateHelper> oh4(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 4*Years, o4, eonia)));
+	boost::shared_ptr<RateHelper> oh5(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 5*Years, o5, eonia)));
+	boost::shared_ptr<RateHelper> oh6(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 7*Years, o6, eonia)));
+	boost::shared_ptr<RateHelper> oh7(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 10*Years, o7, eonia)));
+	boost::shared_ptr<RateHelper> oh8(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 15*Years, o8, eonia)));
+	boost::shared_ptr<RateHelper> oh9(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 20*Years, o9, eonia)));
+	boost::shared_ptr<RateHelper> oh10(boost::shared_ptr<RateHelper>(new OISRateHelper(2, 30*Years, o10, eonia)));
+	insts_ois.push_back(oh1);
+	insts_ois.push_back(oh2);
+	insts_ois.push_back(oh3);
+	insts_ois.push_back(oh4);
+	insts_ois.push_back(oh5);
+	insts_ois.push_back(oh6);
+	insts_ois.push_back(oh7);
+	insts_ois.push_back(oh8);
+	insts_ois.push_back(oh9);
+	insts_ois.push_back(oh10);
+	oisDates.push_back(oh1->latestDate());
+	oisDates.push_back(oh2->latestDate());
+	oisDates.push_back(oh3->latestDate());
+	oisDates.push_back(oh4->latestDate());
+	oisDates.push_back(oh5->latestDate());
+	oisDates.push_back(oh6->latestDate());
+	oisDates.push_back(oh7->latestDate());
+	oisDates.push_back(oh8->latestDate());
+	oisDates.push_back(oh9->latestDate());
+	oisDates.push_back(oh10->latestDate());
+
+	//benchmark
+	boost::shared_ptr<YieldTermStructure> yts_ois_benchmark( 
+		new PiecewiseYieldCurve<ZeroYield, Linear, IterativeBootstrap>(0, TARGET(), insts_ois, Actual365Fixed()));
+	yts_ois_benchmark->enableExtrapolation();
+	yts_ois_benchmark->discount(1.0);  
+
+    //This line is necessary for g++ because of template instantiation. However, under VC++ it works fine without this line. Check it! 
+    boost::shared_ptr<YieldTermStructure> yts_ois( 
+		new PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap>(0, TARGET(), insts_ois, Actual365Fixed(),1.0e-16, Linear()));
+    yts_ois = boost::shared_ptr<YieldTermStructure> (
+                  new QuantLib::PiecewiseYieldCurve<ZeroYield, Linear, QuantLib::MultiBootstrap>(0, TARGET(), insts_ois, Actual365Fixed(),1.0e-16, Linear(),
+                                    QuantLib::MultiBootstrap<QuantLib::PiecewiseYieldCurve<ZeroYield, Linear, QuantLib::MultiBootstrap> >(optimizer)));
+
+	yts_ois->enableExtrapolation();
+
+	//swap curve
+	std::vector<boost::shared_ptr<RateHelper> > insts_swap;
+	std::vector<boost::shared_ptr<RateHelper> > insts_swap2;
+	std::vector<Date> swapDates;
+
+	Handle<Quote> c1(boost::shared_ptr<Quote>(new SimpleQuote(0.00012)));//1m
+	Handle<Quote> c2(boost::shared_ptr<Quote>(new SimpleQuote(0.0005)));//2m
+	Handle<Quote> c3(boost::shared_ptr<Quote>(new SimpleQuote(0.00088)));//3m
+	Handle<Quote> c4(boost::shared_ptr<Quote>(new SimpleQuote(0.00189)));//6m
+	Handle<Quote> c5(boost::shared_ptr<Quote>(new SimpleQuote(0.00341)));//1y
+
+	Handle<Quote> s1(boost::shared_ptr<Quote>(new SimpleQuote(0.00233)));//2y
+	Handle<Quote> s2(boost::shared_ptr<Quote>(new SimpleQuote(0.00291)));//3y
+	Handle<Quote> s3(boost::shared_ptr<Quote>(new SimpleQuote(0.00480)));//5y
+	Handle<Quote> s4(boost::shared_ptr<Quote>(new SimpleQuote(0.00728)));//7y
+	Handle<Quote> s5(boost::shared_ptr<Quote>(new SimpleQuote(0.01104)));//10
+	Handle<Quote> s6(boost::shared_ptr<Quote>(new SimpleQuote(0.01513)));//15y
+	Handle<Quote> s7(boost::shared_ptr<Quote>(new SimpleQuote(0.01715)));//20y
+	Handle<Quote> s8(boost::shared_ptr<Quote>(new SimpleQuote(0.01836)));//30y
+	Handle<Quote> s9(boost::shared_ptr<Quote>(new SimpleQuote(0.01955)));//40y
+
+	boost::shared_ptr<RateHelper> dh1(new QuantLib::DepositRateHelper(c1, 1*Months, 2, TARGET(), ModifiedFollowing, false, Actual360()));
+	boost::shared_ptr<RateHelper> dh2(new QuantLib::DepositRateHelper(c2, 2*Months, 2, TARGET(), ModifiedFollowing, false, Actual360()));
+	boost::shared_ptr<RateHelper> dh3(new QuantLib::DepositRateHelper(c3, 3*Months, 2, TARGET(), ModifiedFollowing, false, Actual360()));
+	boost::shared_ptr<RateHelper> dh4(new QuantLib::DepositRateHelper(c4, 6*Months, 2, TARGET(), ModifiedFollowing, false, Actual360()));
+	boost::shared_ptr<RateHelper> dh5(new QuantLib::DepositRateHelper(c5, 1*Years, 2, TARGET(), ModifiedFollowing, false, Actual360()));
+	
+	//discounted by benchmark OIS curve
+	boost::shared_ptr<RateHelper> sh1(new SwapRateHelper(s1, 2*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+	boost::shared_ptr<RateHelper> sh2(new SwapRateHelper(s2, 3*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+	boost::shared_ptr<RateHelper> sh3(new SwapRateHelper(s3, 5*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+	boost::shared_ptr<RateHelper> sh4(new SwapRateHelper(s4, 7*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+	boost::shared_ptr<RateHelper> sh5(new SwapRateHelper(s5, 10*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+	boost::shared_ptr<RateHelper> sh6(new SwapRateHelper(s6, 15*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+	boost::shared_ptr<RateHelper> sh7(new SwapRateHelper(s7, 20*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+	boost::shared_ptr<RateHelper> sh8(new SwapRateHelper(s8, 30*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+	boost::shared_ptr<RateHelper> sh9(new SwapRateHelper(s9, 40*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_benchmark)));
+
+	//not depend on benchmark OIS Curve
+	boost::shared_ptr<RateHelper> sh_s1(new SwapRateHelper(s1, 2*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh_s2(new SwapRateHelper(s2, 3*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh_s3(new SwapRateHelper(s3, 5*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh_s4(new SwapRateHelper(s4, 7*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh_s5(new SwapRateHelper(s5, 10*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh_s6(new SwapRateHelper(s6, 15*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh_s7(new SwapRateHelper(s7, 20*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh_s8(new SwapRateHelper(s8, 30*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh_s9(new SwapRateHelper(s9, 40*Years, TARGET(), Annual, ModifiedFollowing, Thirty360(), euribor, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	
+	insts_swap.push_back(dh1);
+	insts_swap.push_back(dh2);
+	insts_swap.push_back(dh3);
+	insts_swap.push_back(dh4);
+	insts_swap.push_back(dh5);
+	insts_swap.push_back(sh1);
+	insts_swap.push_back(sh2);
+	insts_swap.push_back(sh3);
+	insts_swap.push_back(sh4);
+	insts_swap.push_back(sh5);
+	insts_swap.push_back(sh6);
+	insts_swap.push_back(sh7);
+	insts_swap.push_back(sh8);
+	insts_swap.push_back(sh9);
+
+	insts_swap2.push_back(dh1);
+	insts_swap2.push_back(dh2);
+	insts_swap2.push_back(dh3);
+	insts_swap2.push_back(dh4);
+	insts_swap2.push_back(dh5);
+	insts_swap2.push_back(sh_s1);
+	insts_swap2.push_back(sh_s2);
+	insts_swap2.push_back(sh_s3);
+	insts_swap2.push_back(sh_s4);
+	insts_swap2.push_back(sh_s5);
+	insts_swap2.push_back(sh_s6);
+	insts_swap2.push_back(sh_s7);
+	insts_swap2.push_back(sh_s8);
+	insts_swap2.push_back(sh_s9);
+
+	swapDates.push_back(dh1->latestDate());
+	swapDates.push_back(dh2->latestDate());
+	swapDates.push_back(dh3->latestDate());
+	swapDates.push_back(dh4->latestDate());
+	swapDates.push_back(dh5->latestDate());
+	swapDates.push_back(sh1->latestDate());
+	swapDates.push_back(sh2->latestDate());
+	swapDates.push_back(sh3->latestDate());
+	swapDates.push_back(sh4->latestDate());
+	swapDates.push_back(sh5->latestDate());
+	swapDates.push_back(sh6->latestDate());
+	swapDates.push_back(sh7->latestDate());
+	swapDates.push_back(sh8->latestDate());
+	swapDates.push_back(sh9->latestDate());
+
+	boost::shared_ptr<YieldTermStructure> yts_swap_benchmark(new QuantLib::PiecewiseYieldCurve<ZeroYield, Linear>(0, TARGET(), insts_swap, Actual365Fixed()));
+	yts_swap_benchmark->enableExtrapolation();
+	yts_swap_benchmark->discount(1.0);
+
+	boost::shared_ptr<YieldTermStructure> yts_swap(
+        new QuantLib::PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap>(0, TARGET(), insts_swap2, Actual365Fixed(),1.0e-16, Linear(),
+		    MultiBootstrap<PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap> >(optimizer)));
+	yts_swap->enableExtrapolation();
+
+	Real tolerance = 1.0e-9;
+	for(Size i = 0; i<oisDates.size(); i++) {
+		if (std::fabs(yts_ois_benchmark->zeroRate(oisDates[i], Actual365Fixed(), Continuous).rate() -
+					  yts_ois->zeroRate(oisDates[i], Actual365Fixed(), Continuous).rate()) > tolerance) {
+			BOOST_ERROR(
+					"\nBenchmark OIS curve not match simultaneously bootstrapped OIS curve on Date " 
+					<< io::iso_date(oisDates[i])
+					<< std::setprecision(12)
+					<< "\n    estimated zero rate: " 
+					<< yts_ois->zeroRate(oisDates[i], Actual365Fixed(), Continuous).rate()
+					<< "\n    expected zero rate:  " 
+					<< yts_ois_benchmark->zeroRate(oisDates[i], Actual365Fixed(), Continuous).rate());
+		}
+	}
+	for(Size i = 0; i<swapDates.size(); i++) {
+		if (std::fabs(yts_swap_benchmark->zeroRate(swapDates[i], Actual365Fixed(), Continuous).rate() -
+					  yts_swap->zeroRate(swapDates[i], Actual365Fixed(), Continuous).rate()) > tolerance) {
+			BOOST_ERROR(
+					"\nBenchmark Swap curve not match simultaneously bootstrapped Swap curve on Date " 
+					<< io::iso_date(swapDates[i])
+					<< std::setprecision(12)
+					<< "\n    estimated discount factor: " 
+					<< yts_swap->zeroRate(swapDates[i], Actual365Fixed(), Continuous).rate()
+					<< "\n    expected discount factor:  " 
+					<< yts_swap_benchmark->zeroRate(swapDates[i], Actual365Fixed(), Continuous).rate());
+		}
+	}
+
+	
+}
+
+void SimultaneousBootstrapTest::testSimultaneousBootstrapConsistency(){
+	BOOST_MESSAGE(
+        "Testing consistency of simultaneous curve bootstrap framework...");
+
+	SavedSettings backup;
+
+	Settings::instance().evaluationDate() = Date(23, Oct, 2014);
+	RelinkableHandle<YieldTermStructure> libor3mProjtionCurve;
+	boost::shared_ptr<IborIndex> liborIndex(new USDLibor(3*Months, libor3mProjtionCurve));
+	boost::shared_ptr<OvernightIndex> overnightIndex(
+		new OvernightIndex("OvernightIndex", 0, USDCurrency(), UnitedStates(UnitedStates::Settlement), Actual360()));
+
+	boost::shared_ptr<MultiCurveOptimizer<PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap> > > 
+				optimizer(new MultiCurveOptimizer<PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap> >());
+
+	//ois quote
+	Handle<Quote> o1m(boost::shared_ptr<Quote>(new SimpleQuote(0.00088)));//1m
+	Handle<Quote> o2m(boost::shared_ptr<Quote>(new SimpleQuote(0.00088)));//2m
+	Handle<Quote> o3m(boost::shared_ptr<Quote>(new SimpleQuote(0.00088)));//3m
+	Handle<Quote> o4m(boost::shared_ptr<Quote>(new SimpleQuote(0.0009)));//4m
+	Handle<Quote> o5m(boost::shared_ptr<Quote>(new SimpleQuote(0.00091)));//5m
+	Handle<Quote> o6m(boost::shared_ptr<Quote>(new SimpleQuote(0.00092)));//6m
+	Handle<Quote> o7m(boost::shared_ptr<Quote>(new SimpleQuote(0.00095)));//7m
+	Handle<Quote> o8m(boost::shared_ptr<Quote>(new SimpleQuote(0.001)));//8m
+	Handle<Quote> o9m(boost::shared_ptr<Quote>(new SimpleQuote(0.00109)));//9m
+	Handle<Quote> o10m(boost::shared_ptr<Quote>(new SimpleQuote(0.00117)));//10m
+	Handle<Quote> o11m(boost::shared_ptr<Quote>(new SimpleQuote(0.00128)));//11m
+	Handle<Quote> o1y(boost::shared_ptr<Quote>(new SimpleQuote(0.00144)));//1y
+	Handle<Quote> o18m(boost::shared_ptr<Quote>(new SimpleQuote(0.00278)));//18m
+	Handle<Quote> o2y(boost::shared_ptr<Quote>(new SimpleQuote(0.00454)));//2y
+	Handle<Quote> o3y(boost::shared_ptr<Quote>(new SimpleQuote(0.000833)));//3y
+	Handle<Quote> o4y(boost::shared_ptr<Quote>(new SimpleQuote(0.01519)));//4y
+	Handle<Quote> o5y(boost::shared_ptr<Quote>(new SimpleQuote(0.01615)));//5y
+
+	//ois ibor basis 
+	Handle<Quote> olb7y(boost::shared_ptr<Quote>(new SimpleQuote(0.002425)));//7y
+	Handle<Quote> olb10y(boost::shared_ptr<Quote>(new SimpleQuote(0.0025125)));//10y
+	Handle<Quote> olb12y(boost::shared_ptr<Quote>(new SimpleQuote(0.0025375)));//15y
+	Handle<Quote> olb15y(boost::shared_ptr<Quote>(new SimpleQuote(0.002575)));//20y
+	Handle<Quote> olb20y(boost::shared_ptr<Quote>(new SimpleQuote(0.0026)));//30y
+	Handle<Quote> olb25y(boost::shared_ptr<Quote>(new SimpleQuote(0.0026)));//30y
+	Handle<Quote> olb30y(boost::shared_ptr<Quote>(new SimpleQuote(0.0026)));//30y
+
+	//swap
+	Handle<Quote> s1y(boost::shared_ptr<Quote>(new SimpleQuote(0.00304)));//1y
+	Handle<Quote> s2y(boost::shared_ptr<Quote>(new SimpleQuote(0.00646)));//2y
+	Handle<Quote> s3y(boost::shared_ptr<Quote>(new SimpleQuote(0.01041)));//3y
+	Handle<Quote> s4y(boost::shared_ptr<Quote>(new SimpleQuote(0.01386)));//4y
+	Handle<Quote> s5y(boost::shared_ptr<Quote>(new SimpleQuote(0.01655)));//5y
+	Handle<Quote> s6y(boost::shared_ptr<Quote>(new SimpleQuote(0.01869)));//6y
+	Handle<Quote> s7y(boost::shared_ptr<Quote>(new SimpleQuote(0.02037)));//7y
+	Handle<Quote> s8y(boost::shared_ptr<Quote>(new SimpleQuote(0.02179)));//8y
+	Handle<Quote> s9y(boost::shared_ptr<Quote>(new SimpleQuote(0.02294)));//9y
+	Handle<Quote> s10y(boost::shared_ptr<Quote>(new SimpleQuote(0.02396)));//10y
+	Handle<Quote> s12y(boost::shared_ptr<Quote>(new SimpleQuote(0.02558)));//12y
+	Handle<Quote> s15y(boost::shared_ptr<Quote>(new SimpleQuote(0.02725)));//15y
+	Handle<Quote> s20y(boost::shared_ptr<Quote>(new SimpleQuote(0.02889)));//20y
+	Handle<Quote> s25y(boost::shared_ptr<Quote>(new SimpleQuote(0.02969)));//25y
+	Handle<Quote> s30y(boost::shared_ptr<Quote>(new SimpleQuote(0.03011)));//30y
+	Handle<Quote> s40y(boost::shared_ptr<Quote>(new SimpleQuote(0.0303)));//40y
+	Handle<Quote> s50y(boost::shared_ptr<Quote>(new SimpleQuote(0.0301)));//50y
+
+	boost::shared_ptr<RateHelper> oh1m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 1*Months, o1m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh2m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 2*Months, o2m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh3m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 3*Months, o3m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh4m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 4*Months, o4m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh5m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 5*Months, o5m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh6m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 6*Months, o6m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh7m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 7*Months, o7m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh8m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 8*Months, o8m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh9m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 9*Months, o9m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh10m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 10*Months, o10m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh11m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 11*Months, o11m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh1y(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 1*Years, o1y, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh18m(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 18*Months, o18m, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh2y(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 2*Years, o2y, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh3y(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 3*Years, o3y, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh4y(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 4*Years, o4y, overnightIndex)));
+	boost::shared_ptr<RateHelper> oh5y(boost::shared_ptr<RateHelper>(new QuantLib::OISRateHelper(0, 5*Years, o5y, overnightIndex)));
+
+	//composite helper of ois libor basis and libor swap
+	boost::shared_ptr<RateHelper> fobh7y(new QuantLib::FixedOISBasisRateHelper(2, 7*Years, olb7y, s7y, QuantLib::Semiannual, ModifiedFollowing, Thirty360(), overnightIndex, Quarterly));
+	boost::shared_ptr<RateHelper> fobh10y(new QuantLib::FixedOISBasisRateHelper(2, 10*Years, olb10y, s10y, QuantLib::Semiannual, ModifiedFollowing, Thirty360(), overnightIndex, Quarterly));
+	boost::shared_ptr<RateHelper> fobh12y(new QuantLib::FixedOISBasisRateHelper(2, 12*Years, olb12y, s12y, QuantLib::Semiannual, ModifiedFollowing, Thirty360(), overnightIndex, Quarterly));
+	boost::shared_ptr<RateHelper> fobh15y(new QuantLib::FixedOISBasisRateHelper(2, 15*Years, olb15y, s15y, QuantLib::Semiannual, ModifiedFollowing, Thirty360(), overnightIndex, Quarterly));
+	boost::shared_ptr<RateHelper> fobh20y(new QuantLib::FixedOISBasisRateHelper(2, 20*Years, olb20y, s20y, QuantLib::Semiannual, ModifiedFollowing, Thirty360(), overnightIndex, Quarterly));
+	boost::shared_ptr<RateHelper> fobh25y(new QuantLib::FixedOISBasisRateHelper(2, 25*Years, olb25y, s25y, QuantLib::Semiannual, ModifiedFollowing, Thirty360(), overnightIndex, Quarterly));
+	boost::shared_ptr<RateHelper> fobh30y(new QuantLib::FixedOISBasisRateHelper(2, 30*Years, olb30y, s30y, QuantLib::Semiannual, ModifiedFollowing, Thirty360(), overnightIndex, Quarterly));
+
+	std::vector<boost::shared_ptr<RateHelper> > insts_ois_composite;
+	std::vector<Date> dates_ois_composite;
+
+	insts_ois_composite.push_back(oh1m);
+	insts_ois_composite.push_back(oh2m);
+	insts_ois_composite.push_back(oh3m);
+	insts_ois_composite.push_back(oh4m);
+	insts_ois_composite.push_back(oh5m);
+	insts_ois_composite.push_back(oh6m);
+	insts_ois_composite.push_back(oh7m);
+	insts_ois_composite.push_back(oh8m);
+	insts_ois_composite.push_back(oh9m);
+	insts_ois_composite.push_back(oh10m);
+	insts_ois_composite.push_back(oh11m);
+	insts_ois_composite.push_back(oh1y);
+	insts_ois_composite.push_back(oh18m);
+	insts_ois_composite.push_back(oh2y);
+	insts_ois_composite.push_back(oh3y);
+	insts_ois_composite.push_back(oh4y);
+	insts_ois_composite.push_back(oh5y);
+
+	insts_ois_composite.push_back(fobh7y);
+	insts_ois_composite.push_back(fobh10y);
+	insts_ois_composite.push_back(fobh12y);
+	insts_ois_composite.push_back(fobh15y);
+	insts_ois_composite.push_back(fobh20y);
+	insts_ois_composite.push_back(fobh25y);
+	insts_ois_composite.push_back(fobh30y);
+
+	dates_ois_composite.push_back(oh1m->latestDate());
+	dates_ois_composite.push_back(oh2m->latestDate());
+	dates_ois_composite.push_back(oh3m->latestDate());
+	dates_ois_composite.push_back(oh4m->latestDate());
+	dates_ois_composite.push_back(oh5m->latestDate());
+	dates_ois_composite.push_back(oh6m->latestDate());
+	dates_ois_composite.push_back(oh7m->latestDate());
+	dates_ois_composite.push_back(oh8m->latestDate());
+	dates_ois_composite.push_back(oh9m->latestDate());
+	dates_ois_composite.push_back(oh10m->latestDate());
+	dates_ois_composite.push_back(oh11m->latestDate());
+	dates_ois_composite.push_back(oh1y->latestDate());
+	dates_ois_composite.push_back(oh18m->latestDate());
+	dates_ois_composite.push_back(oh2y->latestDate());
+	dates_ois_composite.push_back(oh3y->latestDate());
+	dates_ois_composite.push_back(oh4y->latestDate());
+	dates_ois_composite.push_back(oh5y->latestDate());
+
+	dates_ois_composite.push_back(fobh7y->latestDate());
+	dates_ois_composite.push_back(fobh10y->latestDate());
+	dates_ois_composite.push_back(fobh12y->latestDate());
+	dates_ois_composite.push_back(fobh15y->latestDate());
+	dates_ois_composite.push_back(fobh20y->latestDate());
+	dates_ois_composite.push_back(fobh25y->latestDate());
+	dates_ois_composite.push_back(fobh30y->latestDate());
+	//benchmark curve
+	boost::shared_ptr<YieldTermStructure> yts_ois_composite( 
+		new PiecewiseYieldCurve<ZeroYield, Linear>(0, UnitedStates(UnitedStates::Settlement), insts_ois_composite, Actual365Fixed()));
+	yts_ois_composite->enableExtrapolation();
+	yts_ois_composite->discount(1.0);
+
+	boost::shared_ptr<IborIndex> liborIndex_tmp(new USDLibor(3*Months));
+	//swap rate helper depending on yts ois composite curve
+	boost::shared_ptr<RateHelper> sh1y_composite(new SwapRateHelper(s1y, 1*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh2y_composite(new SwapRateHelper(s2y, 2*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh3y_composite(new SwapRateHelper(s3y, 3*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh4y_composite(new SwapRateHelper(s4y, 4*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh5y_composite(new SwapRateHelper(s5y, 5*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh6y_composite(new SwapRateHelper(s6y, 6*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh7y_composite(new SwapRateHelper(s7y, 7*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh8y_composite(new SwapRateHelper(s8y, 8*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh9y_composite(new SwapRateHelper(s9y, 9*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh10y_composite(new SwapRateHelper(s10y, 10*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh12y_composite(new SwapRateHelper(s12y, 12*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh15y_composite(new SwapRateHelper(s15y, 15*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh20y_composite(new SwapRateHelper(s20y, 20*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh25y_composite(new SwapRateHelper(s25y, 25*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh30y_composite(new SwapRateHelper(s30y, 30*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh40y_composite(new SwapRateHelper(s40y, 40*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+	boost::shared_ptr<RateHelper> sh50y_composite(new SwapRateHelper(s50y, 50*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex_tmp, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois_composite)));
+
+	std::vector<boost::shared_ptr<RateHelper> > insts_swap_composite;
+	std::vector<Date> dates_swap_composite;
+
+	insts_swap_composite.push_back(sh1y_composite);
+	insts_swap_composite.push_back(sh2y_composite);
+	insts_swap_composite.push_back(sh3y_composite);
+	insts_swap_composite.push_back(sh4y_composite);
+	insts_swap_composite.push_back(sh5y_composite);
+	insts_swap_composite.push_back(sh6y_composite);
+	insts_swap_composite.push_back(sh7y_composite);
+	insts_swap_composite.push_back(sh8y_composite);
+	insts_swap_composite.push_back(sh9y_composite);
+	insts_swap_composite.push_back(sh10y_composite);
+	insts_swap_composite.push_back(sh12y_composite);
+	insts_swap_composite.push_back(sh15y_composite);
+	insts_swap_composite.push_back(sh20y_composite);
+	insts_swap_composite.push_back(sh25y_composite);
+	insts_swap_composite.push_back(sh30y_composite);
+	insts_swap_composite.push_back(sh40y_composite);
+	insts_swap_composite.push_back(sh50y_composite);
+
+	dates_swap_composite.push_back(sh1y_composite->latestDate());
+	dates_swap_composite.push_back(sh2y_composite->latestDate());
+	dates_swap_composite.push_back(sh3y_composite->latestDate());
+	dates_swap_composite.push_back(sh4y_composite->latestDate());
+	dates_swap_composite.push_back(sh5y_composite->latestDate());
+	dates_swap_composite.push_back(sh6y_composite->latestDate());
+	dates_swap_composite.push_back(sh7y_composite->latestDate());
+	dates_swap_composite.push_back(sh8y_composite->latestDate());
+	dates_swap_composite.push_back(sh9y_composite->latestDate());
+	dates_swap_composite.push_back(sh10y_composite->latestDate());
+	dates_swap_composite.push_back(sh12y_composite->latestDate());
+	dates_swap_composite.push_back(sh15y_composite->latestDate());
+	dates_swap_composite.push_back(sh20y_composite->latestDate());
+	dates_swap_composite.push_back(sh25y_composite->latestDate());
+	dates_swap_composite.push_back(sh30y_composite->latestDate());
+	dates_swap_composite.push_back(sh40y_composite->latestDate());
+	dates_swap_composite.push_back(sh50y_composite->latestDate());
+
+	//benchmark curve
+	boost::shared_ptr<YieldTermStructure> yts_swap_composite(new QuantLib::PiecewiseYieldCurve<ZeroYield, Linear>(0, UnitedStates(UnitedStates::Settlement), insts_swap_composite, Actual365Fixed()));
+	yts_swap_composite->enableExtrapolation();
+	yts_swap_composite->discount(1.0);
+
+
+
+	//ois libor basis helper
+	boost::shared_ptr<RateHelper> olbh7y(new QuantLib::IBOROISBasisRateHelper(2, 7*Years, olb7y, liborIndex, overnightIndex));
+	boost::shared_ptr<RateHelper> olbh10y(new QuantLib::IBOROISBasisRateHelper(2, 10*Years, olb10y, liborIndex, overnightIndex));
+	boost::shared_ptr<RateHelper> olbh12y(new QuantLib::IBOROISBasisRateHelper(2, 12*Years, olb12y, liborIndex, overnightIndex));
+	boost::shared_ptr<RateHelper> olbh15y(new QuantLib::IBOROISBasisRateHelper(2, 15*Years, olb15y, liborIndex, overnightIndex));
+	boost::shared_ptr<RateHelper> olbh20y(new QuantLib::IBOROISBasisRateHelper(2, 20*Years, olb20y, liborIndex, overnightIndex));
+	boost::shared_ptr<RateHelper> olbh25y(new QuantLib::IBOROISBasisRateHelper(2, 25*Years, olb25y, liborIndex, overnightIndex));
+	boost::shared_ptr<RateHelper> olbh30y(new QuantLib::IBOROISBasisRateHelper(2, 30*Years, olb30y, liborIndex, overnightIndex));
+
+	std::vector<boost::shared_ptr<RateHelper> > insts_ois;
+	std::vector<Date> dates_ois;
+
+	insts_ois.push_back(oh1m);
+	insts_ois.push_back(oh2m);
+	insts_ois.push_back(oh3m);
+	insts_ois.push_back(oh4m);
+	insts_ois.push_back(oh5m);
+	insts_ois.push_back(oh6m);
+	insts_ois.push_back(oh7m);
+	insts_ois.push_back(oh8m);
+	insts_ois.push_back(oh9m);
+	insts_ois.push_back(oh10m);
+	insts_ois.push_back(oh11m);
+	insts_ois.push_back(oh1y);
+	insts_ois.push_back(oh18m);
+	insts_ois.push_back(oh2y);
+	insts_ois.push_back(oh3y);
+	insts_ois.push_back(oh4y);
+	insts_ois.push_back(oh5y);
+
+	insts_ois.push_back(olbh7y);
+	insts_ois.push_back(olbh10y);
+	insts_ois.push_back(olbh12y);
+	insts_ois.push_back(olbh15y);
+	insts_ois.push_back(olbh20y);
+	insts_ois.push_back(olbh25y);
+	insts_ois.push_back(olbh30y);
+
+	dates_ois.push_back(oh1m->latestDate());
+	dates_ois.push_back(oh2m->latestDate());
+	dates_ois.push_back(oh3m->latestDate());
+	dates_ois.push_back(oh4m->latestDate());
+	dates_ois.push_back(oh5m->latestDate());
+	dates_ois.push_back(oh6m->latestDate());
+	dates_ois.push_back(oh7m->latestDate());
+	dates_ois.push_back(oh8m->latestDate());
+	dates_ois.push_back(oh9m->latestDate());
+	dates_ois.push_back(oh10m->latestDate());
+	dates_ois.push_back(oh11m->latestDate());
+	dates_ois.push_back(oh1y->latestDate());
+	dates_ois.push_back(oh18m->latestDate());
+	dates_ois.push_back(oh2y->latestDate());
+	dates_ois.push_back(oh3y->latestDate());
+	dates_ois.push_back(oh4y->latestDate());
+	dates_ois.push_back(oh5y->latestDate());
+
+	dates_ois.push_back(olbh7y->latestDate());
+	dates_ois.push_back(olbh10y->latestDate());
+	dates_ois.push_back(olbh12y->latestDate());
+	dates_ois.push_back(olbh15y->latestDate());
+	dates_ois.push_back(olbh20y->latestDate());
+	dates_ois.push_back(olbh25y->latestDate());
+	dates_ois.push_back(olbh30y->latestDate());
+
+	boost::shared_ptr<YieldTermStructure> yts_ois(
+		new QuantLib::PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap>(0, UnitedStates(UnitedStates::Settlement), insts_ois, Actual365Fixed(),1.0e-16, Linear(),
+																			MultiBootstrap<PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap> >(optimizer)));
+	yts_ois->enableExtrapolation();
+
+	//swap rate helper
+	boost::shared_ptr<RateHelper> sh1y(new SwapRateHelper(s1y, 1*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh2y(new SwapRateHelper(s2y, 2*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh3y(new SwapRateHelper(s3y, 3*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh4y(new SwapRateHelper(s4y, 4*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh5y(new SwapRateHelper(s5y, 5*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh6y(new SwapRateHelper(s6y, 6*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh7y(new SwapRateHelper(s7y, 7*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh8y(new SwapRateHelper(s8y, 8*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh9y(new SwapRateHelper(s9y, 9*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh10y(new SwapRateHelper(s10y, 10*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh12y(new SwapRateHelper(s12y, 12*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh15y(new SwapRateHelper(s15y, 15*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh20y(new SwapRateHelper(s20y, 20*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh25y(new SwapRateHelper(s25y, 25*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh30y(new SwapRateHelper(s30y, 30*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh40y(new SwapRateHelper(s40y, 40*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+	boost::shared_ptr<RateHelper> sh50y(new SwapRateHelper(s50y, 50*Years, UnitedStates(UnitedStates::Settlement), Semiannual, ModifiedFollowing, Thirty360(), liborIndex, Handle<Quote>(), 0*Days, Handle<YieldTermStructure>(yts_ois)));
+
+	std::vector<boost::shared_ptr<RateHelper> > insts_swap;
+	std::vector<Date> dates_swap;
+
+	insts_swap.push_back(sh1y);
+	insts_swap.push_back(sh2y);
+	insts_swap.push_back(sh3y);
+	insts_swap.push_back(sh4y);
+	insts_swap.push_back(sh5y);
+	insts_swap.push_back(sh6y);
+	insts_swap.push_back(sh7y);
+	insts_swap.push_back(sh8y);
+	insts_swap.push_back(sh9y);
+	insts_swap.push_back(sh10y);
+	insts_swap.push_back(sh12y);
+	insts_swap.push_back(sh15y);
+	insts_swap.push_back(sh20y);
+	insts_swap.push_back(sh25y);
+	insts_swap.push_back(sh30y);
+	insts_swap.push_back(sh40y);
+	insts_swap.push_back(sh50y);
+
+	dates_swap.push_back(sh1y->latestDate());
+	dates_swap.push_back(sh2y->latestDate());
+	dates_swap.push_back(sh3y->latestDate());
+	dates_swap.push_back(sh4y->latestDate());
+	dates_swap.push_back(sh5y->latestDate());
+	dates_swap.push_back(sh6y->latestDate());
+	dates_swap.push_back(sh7y->latestDate());
+	dates_swap.push_back(sh8y->latestDate());
+	dates_swap.push_back(sh9y->latestDate());
+	dates_swap.push_back(sh10y->latestDate());
+	dates_swap.push_back(sh12y->latestDate());
+	dates_swap.push_back(sh15y->latestDate());
+	dates_swap.push_back(sh20y->latestDate());
+	dates_swap.push_back(sh25y->latestDate());
+	dates_swap.push_back(sh30y->latestDate());
+	dates_swap.push_back(sh40y->latestDate());
+	dates_swap.push_back(sh50y->latestDate());
+
+	boost::shared_ptr<YieldTermStructure> yts_swap(
+        new QuantLib::PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap>(0, UnitedStates(UnitedStates::Settlement), insts_swap, Actual365Fixed(),1.0e-16, 
+                                        Linear(), MultiBootstrap<PiecewiseYieldCurve<ZeroYield, Linear, MultiBootstrap> >(optimizer)));
+	
+	//to tell libor ois swap to use yts_swap curve as projection curve
+	libor3mProjtionCurve.linkTo(yts_swap);
+
+	Real tolerance = 1.0e-9;
+	for(Size i = 0; i<dates_ois_composite.size(); i++) {
+		if (std::fabs(yts_ois_composite->zeroRate(dates_ois_composite[i], Actual365Fixed(), Continuous).rate() -
+					  yts_ois->zeroRate(dates_ois_composite[i], Actual365Fixed(), Continuous).rate()) > tolerance) {
+			BOOST_ERROR(
+					"\nOIS curve from composte rate helper not match simultaneously bootstrapped OIS curve on Date " 
+					<< io::iso_date(dates_ois[i])
+					<< std::setprecision(12)
+					<< "\n    estimated zero rate: " 
+					<< yts_ois->zeroRate(dates_ois[i], Actual365Fixed(), Continuous).rate()
+					<< "\n    expected zero rate:  " 
+					<< yts_ois_composite->zeroRate(dates_ois[i], Actual365Fixed(), Continuous).rate());
+		}
+	}
+	for(Size i = 0; i<dates_swap.size(); i++) {
+		if (std::fabs(yts_swap_composite->zeroRate(dates_swap_composite[i], Actual365Fixed(), Continuous).rate() -
+					  yts_swap->zeroRate(dates_swap_composite[i], Actual365Fixed(), Continuous).rate()) > tolerance) {
+			BOOST_ERROR(
+					"\nSwap curve from composte rate helper not match simultaneously bootstrapped Swap curve on Date " 
+					<< io::iso_date(dates_swap[i])
+					<< std::setprecision(12)
+					<< "\n    estimated zero rate: " 
+					<< yts_swap->zeroRate(dates_swap[i], Actual365Fixed(), Continuous).rate()
+					<< "\n    expected zero rate:  " 
+					<< yts_swap_composite->zeroRate(dates_swap[i], Actual365Fixed(), Continuous).rate());
+		}
+	}
+}
+    
+
+
+test_suite* SimultaneousBootstrapTest::suite() {
+
+    test_suite* suite = BOOST_TEST_SUITE("Simultaneous bootstrap of Piecewise yield curves tests");
+
+    suite->add(QUANTLIB_TEST_CASE(
+                 &SimultaneousBootstrapTest::testDependentCurveBootstrapConsistency));
+	suite->add(QUANTLIB_TEST_CASE(
+                 &SimultaneousBootstrapTest::testSimultaneousBootstrapConsistency));
+
+
+    return suite;
+}
+
+

--- a/QuantLib/test-suite/simultaneouscurvebootstrap.hpp
+++ b/QuantLib/test-suite/simultaneouscurvebootstrap.hpp
@@ -1,0 +1,37 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Yue Tian
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_simultaneous_bootstrap_piecewise_yield_curve_hpp
+#define quantlib_test_simultaneous_bootstrap_piecewise_yield_curve_hpp
+
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class SimultaneousBootstrapTest {
+  public:
+    static void testDependentCurveBootstrapConsistency();
+    static void testSimultaneousBootstrapConsistency();
+
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+
+#endif


### PR DESCRIPTION
This commit creates:
1. ibor ois basis swap with arithmetically averaged ois coupon pricer
2. ibor vs. ois basis swap rate helper and fixed vs. ois swap rate helper
3. bootstrapper for simultaneous multiple curve bootstrap
4. corresponding test-suit to compare the result with curve from iterative bootstrap and ois curve bootstrapped from fixed rate-ois composite instruments and ibor ois basis swap instruments.