### PR TITLE
Fix crash when bond tenor length is 0

### DIFF
--- a/QuantLib/ql/experimental/amortizingbonds/amortizingfixedratebond.cpp
+++ b/QuantLib/ql/experimental/amortizingbonds/amortizingfixedratebond.cpp
@@ -174,7 +174,7 @@ namespace QuantLib {
       frequency_(sinkingFrequency),
       dayCounter_(accrualDayCounter) {
 
-        QL_REQUIRE(bondTenor.length() > 0, "Bond Tenor length can't be 0");
+       QL_REQUIRE(bondTenor.length() > 0, "Bond Tenor length must be positive. " << bondTenor.length() << " is not allowed.");
         maturityDate_ = startDate + bondTenor;
 
         cashflows_ =


### PR DESCRIPTION
In the constructor of `AmortizingFixedRateBond`, if `bondTenor` is accidentally set as length 0, the program will crash from the line 124 in file `amortizingfixedratebond.cpp`. `nPeriods` will be start as 0 and the statement `(Size)nPeriods-1` will roll to a very large positive number.
