### PR TITLE
Fix a bug when copied iterators became invalid.

### DIFF
--- a/QuantLib/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
+++ b/QuantLib/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
@@ -54,13 +54,14 @@ namespace QuantLib {
         const Real dx = 1.0/(size-1);
 
         if(cPoint != Null<Real>()) {
+            std::vector<Real> u, z;
             boost::shared_ptr<Interpolation> transform;
             const Real c1 = asinh((start-cPoint)/density);
             const Real c2 = asinh((end-cPoint)/density);
             if(requireCPoint) {
                 const Real z0 = - c1 / (c2-c1);
                 const Real u0 = static_cast<int>(z0*(size-1)+0.5) / ((Real)(size-1));
-                std::vector<Real> u, z;
+                
                 u.push_back(0.0); u.push_back(u0); u.push_back(1.0);
                 z.push_back(0.0); z.push_back(z0); z.push_back(1.0);
                 transform = boost::shared_ptr<Interpolation>(


### PR DESCRIPTION
Curently in all the interpolation, the array's iterators are all copied but not the actual container content. So these iterators will become invalid without giving any warning when the original contaner went out of its own scope. 

The user who use the derived class of the base interpolation won't know such implementation detail. It is very error prone since user may accidentally miss this point and face the evil of undefined behavior. I have spotted one such bug in the file `concentrating1dmesher.cpp`` .
