### PR TITLE
SwVolCube1: Make MINSTRIKE a regular parameter

### DIFF
--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
@@ -48,8 +48,6 @@
     #define SWAPTIONVOLCUBE_TOL 100.0e-4
 #endif
 
-#define MINSTRIKE 0.0001
-
 namespace QuantLib {
 
     class Interpolation2D;
@@ -132,7 +130,8 @@ namespace QuantLib {
             const Real errorAccept = Null<Real>(),
             const bool useMaxError = false,
             const Size maxGuesses = 50,
-            const bool backwardFlat = false);
+            const bool backwardFlat = false,
+            const Real cutoffStrike = 0.0001);
         //! \name LazyObject interface
         //@{
         void performCalculations() const;
@@ -194,6 +193,7 @@ namespace QuantLib {
         const bool useMaxError_;
         const Size maxGuesses_;
         const bool backwardFlat_;
+        const Real cutoffStrike_;
 
         class PrivateObserver : public Observer {
           public:
@@ -230,7 +230,8 @@ namespace QuantLib {
         Real maxErrorTolerance,
         const boost::shared_ptr<OptimizationMethod> &optMethod,
         const Real errorAccept, const bool useMaxError, const Size maxGuesses,
-        const bool backwardFlat)
+        const bool backwardFlat,
+        const Real cutoffStrike)
         : SwaptionVolatilityCube(atmVolStructure, optionTenors, swapTenors,
                                  strikeSpreads, volSpreads, swapIndexBase,
                                  shortSwapIndexBase, vegaWeightedSmileFit),
@@ -239,7 +240,7 @@ namespace QuantLib {
           isAtmCalibrated_(isAtmCalibrated), endCriteria_(endCriteria),
           optMethod_(optMethod),
           useMaxError_(useMaxError), maxGuesses_(maxGuesses),
-          backwardFlat_(backwardFlat) {
+          backwardFlat_(backwardFlat), cutoffStrike_(cutoffStrike) {
 
         if (maxErrorTolerance != Null<Rate>()) {
             maxErrorTolerance_ = maxErrorTolerance;
@@ -356,7 +357,7 @@ namespace QuantLib {
                 volatilities.clear();
                 for (Size i=0; i<nStrikes_; i++){
                     Real strike = atmForward+strikeSpreads_[i];
-                    if(strike>=MINSTRIKE) {
+                    if(strike>=cutoffStrike_) {
                         strikes.push_back(strike);
                         volatilities.push_back(tmpMarketVolCube[i][j][k]);
                     }
@@ -466,7 +467,7 @@ namespace QuantLib {
             volatilities.clear();
             for (Size i=0; i<nStrikes_; i++){
                 Real strike = atmForward+strikeSpreads_[i];
-                if(strike>=MINSTRIKE) {
+                if(strike>=cutoffStrike_) {
                     strikes.push_back(strike);
                     volatilities.push_back(tmpMarketVolCube[i][j][k]);
                 }
@@ -733,7 +734,7 @@ namespace QuantLib {
         }
 
         for (Size k=0; k<nStrikes_; k++){
-            const Real strike = std::max(atmForward + strikeSpreads_[k],MINSTRIKE);
+            const Real strike = std::max(atmForward + strikeSpreads_[k],cutoffStrike_);
             const Real moneyness = atmForward/strike;
 
             Matrix strikes(2,2,0.);


### PR DESCRIPTION
The minimum strike for which volatility quotes are considered is hardcoded as 1bp currently. I observe problems in the SABR calibration when the forward is only slightly above 2%, so the effective strike of the leftmost quote only slightly above 0%. The calibration seems much more stable if one cuts off all quotes with effective strikes below e.g. 20bp. This PR allows to do so via an additional parameter in the constructor (which is defaulted to the same value as the macro held before, so this does not change anything in existing code).
