### PR TITLE
add hooks to get out pde information

### DIFF
--- a/QuantLib-SWIG/SWIG/options.i
+++ b/QuantLib-SWIG/SWIG/options.i
@@ -125,6 +125,19 @@ ans
 
 %enddef
 
+%define add_price_curve_to(Type)
+
+%extend Type##Ptr {
+    SampledCurve priceCurve() {
+      return boost::dynamic_pointer_cast<Type>(*self)
+	->result<SampledCurve>("priceCurve");
+    }
+    SampledCurve thetaCurve() {
+      return boost::dynamic_pointer_cast<Type>(*self)
+	->result<SampledCurve>("thetaCurve");
+    }
+}
+%enddef
 
 // plain option and engines
 
@@ -152,10 +165,6 @@ class VanillaOptionPtr : public boost::shared_ptr<Instrument> {
             QL_REQUIRE(stPayoff, "wrong payoff given");
             return new VanillaOptionPtr(new VanillaOption(stPayoff,exercise));
         }
-        SampledCurve priceCurve() {
-            return boost::dynamic_pointer_cast<VanillaOption>(*self)
-                ->result<SampledCurve>("priceCurve");
-        }
         Volatility impliedVolatility(
                              Real targetValue,
                              const GeneralizedBlackScholesProcessPtr& process,
@@ -175,7 +184,7 @@ class VanillaOptionPtr : public boost::shared_ptr<Instrument> {
 };
 
 add_greeks_to(VanillaOption);
-
+add_price_curve_to(VanillaOption);
 
 %{
 using QuantLib::EuropeanOption;
@@ -867,10 +876,6 @@ class DividendVanillaOptionPtr : public boost::shared_ptr<Instrument> {
                           new DividendVanillaOption(stPayoff,exercise,
                                                     dividendDates,dividends));
         }
-        SampledCurve priceCurve() {
-            return boost::dynamic_pointer_cast<DividendVanillaOption>(*self)
-                ->result<SampledCurve>("priceCurve");
-        }
         Volatility impliedVolatility(
                              Real targetValue,
                              const GeneralizedBlackScholesProcessPtr& process,
@@ -890,7 +895,7 @@ class DividendVanillaOptionPtr : public boost::shared_ptr<Instrument> {
 };
 
 add_greeks_to(DividendVanillaOption);
-
+add_price_curve_to(DividendVanillaOption);
 
 %{
 using QuantLib::AnalyticDividendEuropeanEngine;
@@ -992,10 +997,6 @@ class BarrierOptionPtr : public boost::shared_ptr<Instrument> {
                                new BarrierOption(barrierType, barrier, rebate,
                                                  stPayoff,exercise));
         }
-        SampledCurve priceCurve() {
-            return boost::dynamic_pointer_cast<BarrierOption>(*self)
-                ->result<SampledCurve>("priceCurve");
-        }
         Volatility impliedVolatility(
                              Real targetValue,
                              const GeneralizedBlackScholesProcessPtr& process,
@@ -1015,6 +1016,7 @@ class BarrierOptionPtr : public boost::shared_ptr<Instrument> {
 };
 
 add_greeks_to(BarrierOption);
+add_price_curve_to(BarrierOption);
 
 
 // Barrier engines
@@ -1249,7 +1251,6 @@ class ContinuousAveragingAsianOptionPtr : public boost::shared_ptr<Instrument> {
 };
 
 add_greeks_to(ContinuousAveragingAsianOption);
-
 
 %rename(DiscreteAveragingAsianOption) DiscreteAveragingAsianOptionPtr;
 class DiscreteAveragingAsianOptionPtr : public boost::shared_ptr<Instrument> {

--- a/QuantLib-SWIG/SWIG/sampledcurve.i
+++ b/QuantLib-SWIG/SWIG/sampledcurve.i
@@ -39,6 +39,9 @@ class SampledCurve {
     void shiftGrid(Real s);
     void scaleGrid(Real s);
     void regrid(const Array &);
+    Real firstDerivativeAtCenter();
+    Real secondDerivativeAtCenter();
+    SampledCurve derivative() const;
 };
 
 

--- a/QuantLib/ql/math/sampledcurve.cpp
+++ b/QuantLib/ql/math/sampledcurve.cpp
@@ -30,6 +30,18 @@ namespace QuantLib {
             return (values_[jmid]+values_[jmid-1])/2.0;
     }
 
+    SampledCurve SampledCurve::derivative() const {
+        QL_REQUIRE(size()>=3,
+                   "the size of the curve must be at least 3");
+        SampledCurve retval(size()-2);
+        for (Size i=0; i < size()-2; i++) {
+            retval.gridValue(i) = grid_[i+1];
+            retval.value(i) = 
+                (values_[i+2] - values_[i]) / (grid_[i+2] - grid_[i]);
+        }
+        return retval;
+    }
+
     Real SampledCurve::firstDerivativeAtCenter() const {
         QL_REQUIRE(size()>=3,
                    "the size of the curve must be at least 3");

--- a/QuantLib/ql/math/sampledcurve.hpp
+++ b/QuantLib/ql/math/sampledcurve.hpp
@@ -79,6 +79,7 @@ namespace QuantLib {
                   secondDerivativeAt(spot)
         */
         Real secondDerivativeAtCenter() const;
+        SampledCurve derivative() const;
         //@}
 
         //! \name utilities

--- a/QuantLib/ql/pricingengines/vanilla/fdeuropeanengine.hpp
+++ b/QuantLib/ql/pricingengines/vanilla/fdeuropeanengine.hpp
@@ -81,8 +81,13 @@ namespace QuantLib {
                                            results_.delta,
                                            results_.gamma);
         results_.additionalResults["priceCurve"] = prices_;
+        if (model.prevDt() > 0.0) {
+            SampledCurve thetaCurve = prices_;
+            thetaCurve.values() = 
+                (prices_.values() - model.prevValue()) / model.prevDt();
+            results_.additionalResults["thetaCurve"] = thetaCurve;
+        }
     }
-
 }
 
 

--- a/QuantLib/ql/pricingengines/vanilla/fdmultiperiodengine.hpp
+++ b/QuantLib/ql/pricingengines/vanilla/fdmultiperiodengine.hpp
@@ -185,6 +185,13 @@ namespace QuantLib {
         results->delta = prices_.firstDerivativeAtCenter();
         results->gamma = prices_.secondDerivativeAtCenter();
         results->additionalResults["priceCurve"] = prices_;
+        if (model_->prevDt() > 0.0) {
+            SampledCurve thetaCurve = prices_;
+            thetaCurve.values() =
+                (prices_.values() - model_->prevValue()) / 
+                model_->prevDt(); 
+            results->additionalResults["thetaCurve"] = thetaCurve;  
+        }
     }
 
     template <template <class> class Scheme>

--- a/QuantLib/ql/pricingengines/vanilla/fdstepconditionengine.hpp
+++ b/QuantLib/ql/pricingengines/vanilla/fdstepconditionengine.hpp
@@ -131,6 +131,12 @@ namespace QuantLib {
             - controlPrices_.secondDerivativeAtCenter()
             + black.gamma(spot);
         results->additionalResults["priceCurve"] = prices_;
+        if (model.prevDt() > 0.0) {
+            SampledCurve thetaCurve = prices_;
+            thetaCurve.values() = 
+                (prices_.values() - model.prevValue()[0]) / model.prevDt();
+            results->additionalResults["thetaCurve"] = thetaCurve;
+        }
     }
 
 }


### PR DESCRIPTION
This patch adds hooks to pull out PDE information so that it is
possible to run one PDE calculation, and get greeks for the
entire calculated grid.