### PR TITLE
Disabled a large number of C4251 warning caused by the dll-export of two classes that have std::string as private members.

### DIFF
--- a/ObjectHandler/ohxl/functioncall.hpp
+++ b/ObjectHandler/ohxl/functioncall.hpp
@@ -125,9 +125,12 @@ namespace ObjectHandler {
 
     private:
         static FunctionCall *instance_;
+#pragma warning(push)
+#pragma warning(disable: 4251)
         std::string functionName_;
         std::string address_;
         std::string refStr_;
+#pragma warning(pop)
         Xloper xCaller_;
         Xloper xReftext_;
         Xloper xMulti_;

--- a/ObjectHandler/ohxl/repositoryxl.hpp
+++ b/ObjectHandler/ohxl/repositoryxl.hpp
@@ -135,7 +135,10 @@ namespace ObjectHandler {
         // Retrieve a reference to the CallingRange object associated to the active cell.
         boost::shared_ptr<CallingRange> getCallingRange();
         // Error associated with VBA
+#pragma warning(push)
+#pragma warning(disable: 4251)
         std::string vbaError_;
+#pragma warning(pop)
     };
 
 }


### PR DESCRIPTION
If anyone can solve the warnings without just suppress it, please update the PR.
(thanks to Ittegrat for the commit)
