### PR TITLE
add normal volatilities for swaptions

### DIFF
--- a/QuantLib/ql/cashflows/lineartsrpricer.cpp
+++ b/QuantLib/ql/cashflows/lineartsrpricer.cpp
@@ -281,16 +281,24 @@ namespace QuantLib {
             Real atm = smileSection_->atmLevel();
             Real atmVol = smileSection_->volatility(atm);
             Real shift = smileSection_->shift();
-            Real upperTmp =
-                (atm + shift) * std::exp(settings_.stdDevs_ * atmVol -
-                                         0.5 * atmVol * atmVol *
-                                             smileSection_->exerciseTime()) -
-                shift;
-            Real lowerTmp =
-                (atm + shift) * std::exp(-settings_.stdDevs_ * atmVol -
-                                         0.5 * atmVol * atmVol *
-                                             smileSection_->exerciseTime()) -
-                shift;
+            Real lowerTmp, upperTmp;
+            if (smileSection_->volatilityType() == ShiftedLognormal) {
+                upperTmp = (atm + shift) *
+                               std::exp(settings_.stdDevs_ * atmVol -
+                                        0.5 * atmVol * atmVol *
+                                            smileSection_->exerciseTime()) -
+                           shift;
+                lowerTmp = (atm + shift) *
+                               std::exp(-settings_.stdDevs_ * atmVol -
+                                        0.5 * atmVol * atmVol *
+                                            smileSection_->exerciseTime()) -
+                           shift;
+            } else {
+                Real tmp = settings_.stdDevs_ * atmVol *
+                           std::sqrt(smileSection_->exerciseTime());
+                upperTmp = atm + tmp;
+                lowerTmp = atm - tmp;
+            }
             upper = std::min(upperTmp - shift, shiftedUpperBound_);
             lower = std::max(lowerTmp - shift, shiftedLowerBound_);
             break;

--- a/QuantLib/ql/cashflows/lineartsrpricer.hpp
+++ b/QuantLib/ql/cashflows/lineartsrpricer.hpp
@@ -54,6 +54,9 @@ namespace QuantLib {
         lower and upper bound are applied to strike + shift so that
         e.g. a zero lower bound always refers to the lower bound of
         the rates in the shifted lognormal model.
+        Note that for normal volatility input the lower rate bound
+        should probably be adjusted to an appropriate negative value,
+        there is no automatic adjustment in this case.
     */
 
     class LinearTsrPricer : public CmsCouponPricer, public MeanRevertingPricer {

--- a/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
+++ b/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
@@ -97,7 +97,7 @@ namespace QuantLib {
 
     const Real LognormalCmsSpreadPricer::integrand_normal(const Real x) const {
 
-        // this is http://ssrn.com/abstract=2686998, with x = s / sqrt(2)
+        // this is http://ssrn.com/abstract=2686998, 3.20 with x = s / sqrt(2)
 
         Real s = M_SQRT2 * x;
 

--- a/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
+++ b/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
@@ -69,7 +69,7 @@ namespace QuantLib {
 
     const Real LognormalCmsSpreadPricer::integrand(const Real x) const {
 
-        // this is Brigo, 13.16.2 with x = v/sqrt(2)
+        // this is Brigo, 13.16.2 with x = v / sqrt(2)
 
         Real v = M_SQRT2 * x;
         Real h =
@@ -97,7 +97,7 @@ namespace QuantLib {
 
     const Real LognormalCmsSpreadPricer::integrand_normal(const Real x) const {
 
-        // this is (... add reference ...) with x = s / sqrt(2)
+        // this is http://ssrn.com/abstract=2686998, with x = s / sqrt(2)
 
         Real s = M_SQRT2 * x;
 

--- a/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
+++ b/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /*
-  Copyright (C) 2014 Peter Caspers
+  Copyright (C) 2014, 2015 Peter Caspers
 
   This file is part of QuantLib, a free-software/open-source library
   for financial quantitative analysts and developers - http://quantlib.org/
@@ -32,7 +32,9 @@ namespace QuantLib {
         const boost::shared_ptr<CmsCouponPricer> cmsPricer,
         const Handle<Quote> &correlation,
         const Handle<YieldTermStructure> &couponDiscountCurve,
-        const Size integrationPoints)
+        const Size integrationPoints,
+        const boost::optional<VolatilityType> volatilityType,
+        const Real shift1, const Real shift2)
         : CmsSpreadCouponPricer(correlation), cmsPricer_(cmsPricer),
           couponDiscountCurve_(couponDiscountCurve) {
 
@@ -50,6 +52,19 @@ namespace QuantLib {
 
         privateObserver_ = boost::make_shared<PrivateObserver>(this);
         privateObserver_->registerWith(cmsPricer_);
+
+        if(volatilityType == boost::none) {
+            QL_REQUIRE(shift1 == Null<Real>() && shift2 == Null<Real>(),
+                       "if volatility type is inherited, no shifts should be "
+                       "specified");
+            inheritedVolatilityType_ = true;
+            volType_ = cmsPricer->swaptionVolatility()->volatilityType();
+        } else {
+            shift1_ = shift1 == Null<Real>() ? 0.0 : shift1;
+            shift2_ = shift2 == Null<Real>() ? 0.0 : shift2;
+            inheritedVolatilityType_ = false;
+            volType_ = *volatilityType;
+        }
     }
 
     const Real LognormalCmsSpreadPricer::integrand(const Real x) const {
@@ -59,25 +74,45 @@ namespace QuantLib {
         Real v = M_SQRT2 * x;
         Real h =
             k_ - b_ * s2_ * std::exp((m2_ - 0.5 * v2_ * v2_) * fixingTime_ +
-                                     v2_ * sqrt(fixingTime_) * v);
+                                     v2_ * std::sqrt(fixingTime_) * v);
         Real phi1, phi2;
         phi1 = cnd_->operator()(
             phi_ * (std::log(a_ * s1_ / h) +
                     (m1_ + (0.5 - rho_ * rho_) * v1_ * v1_) * fixingTime_ +
                     rho_ * v1_ * std::sqrt(fixingTime_) * v) /
-            (v1_ * sqrt(fixingTime_ * (1.0 - rho_ * rho_))));
+            (v1_ * std::sqrt(fixingTime_ * (1.0 - rho_ * rho_))));
         phi2 =
             cnd_->operator()(phi_ * (std::log(a_ * s1_ / h) +
                                      (m1_ - 0.5 * v1_ * v1_) * fixingTime_ +
                                      rho_ * v1_ * std::sqrt(fixingTime_) * v) /
-                             (v1_ * sqrt(fixingTime_ * (1.0 - rho_ * rho_))));
+                             (v1_ * std::sqrt(fixingTime_ * (1.0 - rho_ * rho_))));
         Real f = a_ * phi_ * s1_ *
                      std::exp(m1_ * fixingTime_ -
                               0.5 * rho_ * rho_ * v1_ * v1_ * fixingTime_ +
-                              rho_ * v1_ * sqrt(fixingTime_) * v) *
+                              rho_ * v1_ * std::sqrt(fixingTime_) * v) *
                      phi1 -
                  phi_ * h * phi2;
-        return 1.0 / M_SQRTPI * std::exp(-x * x) * f;
+        return std::exp(-x * x) * f;
+    }
+
+    const Real LognormalCmsSpreadPricer::integrand_normal(const Real x) const {
+
+        // this is (... add reference ...) with x = s / sqrt(2)
+
+        Real s = M_SQRT2 * x;
+
+        Real beta =
+            phi_ *
+            (gearing1_ * adjustedRate1_ + gearing2_ * adjustedRate2_ - k_ +
+             std::sqrt(fixingTime_) *
+                 (rho_ * gearing1_ * vol1_ + gearing2_ * vol2_) * s);
+        Real f =
+            close_enough(alpha_, 0.0)
+                ? std::max(beta, 0.0)
+                : psi_ * alpha_ / (M_SQRTPI * M_SQRT2) *
+                          std::exp(-beta * beta / (2.0 * alpha_ * alpha_)) +
+                      beta * (1.0 - cnd_->operator()(-psi_ * beta / alpha_));
+        return std::exp(-x * x) * f;
     }
 
     void LognormalCmsSpreadPricer::flushCache() { cache_.clear(); }
@@ -166,7 +201,19 @@ namespace QuantLib {
             boost::shared_ptr<SwaptionVolatilityCube> swcub =
                 boost::dynamic_pointer_cast<SwaptionVolatilityCube>(swvol);
 
+            if(inheritedVolatilityType_ && volType_ == ShiftedLognormal) {
+                shift1_ =
+                    swvol->shift(fixingDate_, index_->swapIndex1()->tenor());
+                shift2_ =
+                    swvol->shift(fixingDate_, index_->swapIndex1()->tenor());
+            }
+
             if (swcub == NULL) {
+                // not a cube, just an atm surface given, so we can
+                // not easily convert volatilities and just forbid it
+                QL_REQUIRE(inheritedVolatilityType_,
+                           "if only an atm surface is given, the volatility "
+                           "type must be inherited");
                 vol1_ = swvol->volatility(
                     fixingDate_, index_->swapIndex1()->tenor(), swapRate1_);
                 vol2_ = swvol->volatility(
@@ -174,16 +221,20 @@ namespace QuantLib {
             } else {
                 vol1_ = swcub->smileSection(fixingDate_,
                                             index_->swapIndex1()->tenor())
-                            ->volatility(swapRate1_,
-                                         ShiftedLognormal, 0.0);
+                            ->volatility(swapRate1_, volType_, shift1_);
                 vol2_ = swcub->smileSection(fixingDate_,
                                             index_->swapIndex2()->tenor())
-                            ->volatility(swapRate2_,
-                                         ShiftedLognormal, 0.0);
+                            ->volatility(swapRate2_, volType_, shift2_);
             }
 
-            mu1_ = 1.0 / fixingTime_ * std::log(adjustedRate1_ / swapRate1_);
-            mu2_ = 1.0 / fixingTime_ * std::log(adjustedRate2_ / swapRate2_);
+            if(volType_ == ShiftedLognormal) {
+                mu1_ = 1.0 / fixingTime_ * std::log((adjustedRate1_ + shift1_) /
+                                                    (swapRate1_ + shift1_));
+                mu2_ = 1.0 / fixingTime_ * std::log((adjustedRate2_ + shift2_) /
+                                                    (swapRate2_ + shift2_));
+            }
+            // for the normal volatility case we do not need the drifts
+            // but rather use adjusted rates directly in the integrand
 
             rho_ = std::max(std::min(correlation()->value(), 0.9999),
                             -0.9999); // avoid division by zero in integrand
@@ -195,32 +246,46 @@ namespace QuantLib {
 
         phi_ = optionType == Option::Call ? 1.0 : -1.0;
         Real res = 0.0;
-        if (strike >= 0.0) {
-            a_ = gearing1_;
-            b_ = gearing2_;
-            s1_ = swapRate1_;
-            s2_ = swapRate2_;
-            m1_ = mu1_;
-            m2_ = mu2_;
-            v1_ = vol1_;
-            v2_ = vol2_;
-            k_ = strike;
+        if (volType_ == ShiftedLognormal) {
+            if (strike >= 0.0) {
+                a_ = gearing1_;
+                b_ = gearing2_;
+                s1_ = swapRate1_ + shift1_;
+                s2_ = swapRate2_ + shift2_;
+                m1_ = mu1_;
+                m2_ = mu2_;
+                v1_ = vol1_;
+                v2_ = vol2_;
+                k_ = strike + gearing1_ * shift1_ + gearing2_ * shift2_;
+            } else {
+                a_ = -gearing2_;
+                b_ = -gearing1_;
+                s1_ = swapRate2_ + shift1_;
+                s2_ = swapRate1_ + shift2_;
+                m1_ = mu2_;
+                m2_ = mu1_;
+                v1_ = vol2_;
+                v2_ = vol1_;
+                k_ = -strike - gearing1_ * shift1_ - gearing2_ * shift2_;
+                res += phi_ * (gearing1_ * adjustedRate1_ +
+                               gearing2_ * adjustedRate2_ - strike);
+            }
+            res +=
+                1.0 / M_SQRTPI *
+                integrator_->operator()(std::bind1st(
+                    std::mem_fun(&LognormalCmsSpreadPricer::integrand), this));
         } else {
-            a_ = -gearing2_;
-            b_ = -gearing1_;
-            s1_ = swapRate2_;
-            s2_ = swapRate1_;
-            m1_ = mu2_;
-            m2_ = mu1_;
-            v1_ = vol2_;
-            v2_ = vol1_;
-            k_ = -strike;
-            res += phi_ * (gearing1_ * adjustedRate1_ +
-                           gearing2_ * adjustedRate2_ - strike);
+            // normal volatility
+            k_ = strike;
+            alpha_ = phi_ * gearing1_ * vol1_ *
+                     std::sqrt(fixingTime_ * (1.0 - rho_ * rho_));
+            psi_ = alpha_ >= 0.0 ? 1.0 : -1.0;
+            res +=
+                1.0 / M_SQRTPI *
+                integrator_->operator()(std::bind1st(
+                    std::mem_fun(&LognormalCmsSpreadPricer::integrand_normal),
+                    this));
         }
-
-        res += integrator_->operator()(std::bind1st(
-            std::mem_fun(&LognormalCmsSpreadPricer::integrand), this));
         return res * couponDiscountCurve_->discount(paymentDate_) *
                coupon_->accrualPeriod();
     }

--- a/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.hpp
+++ b/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.hpp
@@ -40,11 +40,19 @@ namespace QuantLib {
     /*! The swap rate adjustments are computed using the given
         volatility structures for the underlyings in every case
         (w.r.t. volatility type and shift).
+
         For the bivariate spread model, the volatility type and
         the shifts can be inherited (default), or explicitly
         specified. In the latter case the type, and (if lognormal)
         the shifts must be given (or are defaulted to zero, if not
         given).
+
+        References:
+
+        Brigo, Mercurio: Interst Rate Models - Theory and Practice,
+        2nd Edition, Springer, 2006, chapter 13.6.2
+
+        http://ssrn.com/abstract=2686998
     */
 
     class LognormalCmsSpreadPricer : public CmsSpreadCouponPricer {

--- a/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.hpp
+++ b/QuantLib/ql/experimental/coupons/lognormalcmsspreadpricer.hpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /*
-  Copyright (C) 2014 Peter Caspers
+  Copyright (C) 2014, 2015 Peter Caspers
 
   This file is part of QuantLib, a free-software/open-source library
   for financial quantitative analysts and developers - http://quantlib.org/
@@ -17,7 +17,9 @@
   or FITNESS FOR A PARTICULAR PURPOSE. See the license for more details. */
 
 /*! \file lognormalcmsspreadpricer.hpp
-    \brief cms spread coupon pricer as in Brigo, Mercurio, 13.34
+    \brief cms spread coupon pricer as in Brigo, Mercurio, 13.34 with
+           extensions for shifted lognormal and normal dynamics as in
+           (... add reference ...)
 */
 
 #ifndef quantlib_lognormal_cmsspread_pricer_hpp
@@ -35,7 +37,14 @@ namespace QuantLib {
     class YieldTermStructure;
 
     //! CMS spread - coupon pricer
-    /*! blah blah...
+    /*! The swap rate adjustments are computed using the given
+        volatility structures for the underlyings in every case
+        (w.r.t. volatility type and shift).
+        For the bivariate spread model, the volatility type and
+        the shifts can be inherited (default), or explicitly
+        specified. In the latter case the type, and (if lognormal)
+        the shifts must be given (or are defaulted to zero, if not
+        given).
     */
 
     class LognormalCmsSpreadPricer : public CmsSpreadCouponPricer {
@@ -46,7 +55,9 @@ namespace QuantLib {
             const Handle<Quote> &correlation,
             const Handle<YieldTermStructure> &couponDiscountCurve =
                 Handle<YieldTermStructure>(),
-            const Size IntegrationPoints = 16);
+            const Size IntegrationPoints = 16,
+            const boost::optional<VolatilityType> volatilityType= boost::none,
+            const Real shift1 = Null<Real>(), const Real shift2 = Null<Real>());
 
         /* */
         virtual Real swapletPrice() const;
@@ -77,6 +88,7 @@ namespace QuantLib {
         Real optionletPrice(Option::Type optionType, Real strike) const;
 
         const Real integrand(const Real) const;
+        const Real integrand_normal(const Real) const;
 
         boost::shared_ptr<CmsCouponPricer> cmsPricer_;
 
@@ -102,7 +114,12 @@ namespace QuantLib {
         Real mu1_, mu2_;
         Real rho_;
 
+        bool inheritedVolatilityType_;
+        VolatilityType volType_;
+        Real shift1_, shift2_;
+
         mutable Real phi_, a_, b_, s1_, s2_, m1_, m2_, v1_, v2_, k_;
+        mutable Real alpha_, psi_;
 
         boost::shared_ptr<CmsCoupon> c1_, c2_;
 

--- a/QuantLib/ql/models/calibrationhelper.cpp
+++ b/QuantLib/ql/models/calibrationhelper.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2001, 2002, 2003 Sadruddin Rejeb
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -60,19 +61,21 @@ namespace QuantLib {
             break;
           case ImpliedVolError: 
             {
-              const Real lowerPrice = blackPrice(0.001);
-              const Real upperPrice = blackPrice(10);
+              Real minVol = volatilityType_ == ShiftedLognormal ? 0.0010 : 0.00005;
+              Real maxVol = volatilityType_ == ShiftedLognormal ? 10.0 : 0.50;
+              const Real lowerPrice = blackPrice(minVol);
+              const Real upperPrice = blackPrice(maxVol);
               const Real modelPrice = modelValue();
 
               Volatility implied;
               if (modelPrice <= lowerPrice)
-                  implied = 0.001;
+                  implied = minVol;
               else
                   if (modelPrice >= upperPrice)
-                      implied = 10.0;
+                      implied = maxVol;
                   else
                       implied = this->impliedVolatility(
-                                          modelPrice, 1e-12, 5000, 0.001, 10);
+                                          modelPrice, 1e-12, 5000, minVol, maxVol);
               error = implied - volatility_->value();
             }
             break;

--- a/QuantLib/ql/models/calibrationhelper.hpp
+++ b/QuantLib/ql/models/calibrationhelper.hpp
@@ -28,8 +28,11 @@
 
 #include <ql/quote.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/termstructures/volatility/volatilitytype.hpp>
 #include <ql/patterns/lazyobject.hpp>
+
 #include <list>
+
 
 namespace QuantLib {
 
@@ -42,10 +45,11 @@ namespace QuantLib {
                             RelativePriceError, PriceError, ImpliedVolError};
         CalibrationHelper(const Handle<Quote>& volatility,
                           const Handle<YieldTermStructure>& termStructure,
-                          CalibrationErrorType calibrationErrorType 
-                                                          = RelativePriceError)
+                          CalibrationErrorType calibrationErrorType
+                          = RelativePriceError, const VolatilityType type = ShiftedLognormal,
+                          const Real shift = 0.0)
         : volatility_(volatility), termStructure_(termStructure),
-          calibrationErrorType_(calibrationErrorType) {
+          volatilityType_(type), shift_(shift), calibrationErrorType_(calibrationErrorType) {
             registerWith(volatility_);
             registerWith(termStructure_);
         }
@@ -75,7 +79,7 @@ namespace QuantLib {
                                      Volatility minVol,
                                      Volatility maxVol) const;
 
-        //! Black price given a volatility
+        //! Black or Bachelier price given a volatility
         virtual Real blackPrice(Volatility volatility) const = 0;
 
         void setPricingEngine(const boost::shared_ptr<PricingEngine>& engine) {
@@ -87,6 +91,8 @@ namespace QuantLib {
         Handle<Quote> volatility_;
         Handle<YieldTermStructure> termStructure_;
         boost::shared_ptr<PricingEngine> engine_;
+        const VolatilityType volatilityType_;
+        const Real shift_;
 
       private:
         class ImpliedVolatilityHelper;

--- a/QuantLib/ql/models/shortrate/calibrationhelpers/swaptionhelper.hpp
+++ b/QuantLib/ql/models/shortrate/calibrationhelpers/swaptionhelper.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2001, 2002, 2003 Sadruddin Rejeb
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -26,6 +27,7 @@
 
 #include <ql/models/calibrationhelper.hpp>
 #include <ql/instruments/swaption.hpp>
+#include <ql/termstructures/volatility/volatilitytype.hpp>
 
 namespace QuantLib {
 
@@ -45,6 +47,7 @@ namespace QuantLib {
                                       = CalibrationHelper::RelativePriceError,
                        const Real strike = Null<Real>(),
                        const Real nominal = 1.0,
+                       const VolatilityType type = ShiftedLognormal,
                        const Real shift = 0.0);
 
         SwaptionHelper(const Date& exerciseDate,
@@ -59,6 +62,7 @@ namespace QuantLib {
                                       = CalibrationHelper::RelativePriceError,
                        const Real strike = Null<Real>(),
                        const Real nominal = 1.0,
+                       const VolatilityType type = ShiftedLognormal,
                        const Real shift = 0.0);
 
         SwaptionHelper(const Date& exerciseDate,
@@ -73,6 +77,7 @@ namespace QuantLib {
                                       = CalibrationHelper::RelativePriceError,
                        const Real strike = Null<Real>(),
                        const Real nominal = 1.0,
+                       const VolatilityType type = ShiftedLognormal,
                        const Real shift = 0.0);
 
         virtual void addTimesTo(std::list<Time>& times) const;
@@ -89,6 +94,7 @@ namespace QuantLib {
         const boost::shared_ptr<IborIndex> index_;
         const DayCounter fixedLegDayCounter_, floatingLegDayCounter_;
         const Real strike_, nominal_, shift_;
+        const VolatilityType volatilityType_;
         mutable Rate exerciseRate_;
         mutable boost::shared_ptr<VanillaSwap> swap_;
         mutable boost::shared_ptr<Swaption> swaption_;

--- a/QuantLib/ql/pricingengines/swaption/basketgeneratingengine.cpp
+++ b/QuantLib/ql/pricingengines/swaption/basketgeneratingengine.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2013 Peter Caspers
+ Copyright (C) 2013, 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -96,7 +96,8 @@ namespace QuantLib {
                     standardSwapBase->exogenousDiscount()
                         ? standardSwapBase->discountingTermStructure()
                         : standardSwapBase->forwardingTermStructure(),
-                    CalibrationHelper::RelativePriceError, Null<Real>(), 1.0, shift));
+                    CalibrationHelper::RelativePriceError, Null<Real>(), 1.0,
+                    swaptionVolatility->volatilityType() ,shift));
 
                 break;
             }
@@ -225,7 +226,7 @@ namespace QuantLib {
                         ? standardSwapBase->discountingTermStructure()
                         : standardSwapBase->forwardingTermStructure(),
                     CalibrationHelper::RelativePriceError, solution[2],
-                    fabs(solution[0]),shift));
+                    fabs(solution[0]), swaptionVolatility->volatilityType(), shift));
                 break;
             }
 

--- a/QuantLib/ql/pricingengines/swaption/blackswaptionengine.cpp
+++ b/QuantLib/ql/pricingengines/swaption/blackswaptionengine.cpp
@@ -28,33 +28,33 @@ namespace QuantLib {
     BlackSwaptionEngine::BlackSwaptionEngine(const Handle<YieldTermStructure> &discountCurve,
                         Volatility vol, const DayCounter &dc,
                         Real displacement)
-        : BlackTypedSwaptionEngine<detail::Black76Spec>(discountCurve, vol, dc,
+        : BlackStyleSwaptionEngine<detail::Black76Spec>(discountCurve, vol, dc,
                                                 displacement) {}
     BlackSwaptionEngine::BlackSwaptionEngine(const Handle<YieldTermStructure> &discountCurve,
                         const Handle<Quote> &vol,
                         const DayCounter &dc,
                         Real displacement)
-        : BlackTypedSwaptionEngine<detail::Black76Spec>(discountCurve, vol, dc,
+        : BlackStyleSwaptionEngine<detail::Black76Spec>(discountCurve, vol, dc,
                                                 displacement) {}
     BlackSwaptionEngine::BlackSwaptionEngine(const Handle<YieldTermStructure> &discountCurve,
                         const Handle<SwaptionVolatilityStructure> &vol,
                         Real displacement)
-        : BlackTypedSwaptionEngine<detail::Black76Spec>(discountCurve, vol,
+        : BlackStyleSwaptionEngine<detail::Black76Spec>(discountCurve, vol,
                                                 displacement) {}
 
     BachelierBlackSwaptionEngine::BachelierBlackSwaptionEngine(
         const Handle<YieldTermStructure> &discountCurve, Volatility vol,
         const DayCounter &dc)
-        : BlackTypedSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
+        : BlackStyleSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
                                                           dc, 0.0) {}
     BachelierBlackSwaptionEngine::BachelierBlackSwaptionEngine(
         const Handle<YieldTermStructure> &discountCurve,
         const Handle<Quote> &vol, const DayCounter &dc)
-        : BlackTypedSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
+        : BlackStyleSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
                                                           dc, 0.0) {}
     BachelierBlackSwaptionEngine::BachelierBlackSwaptionEngine(
         const Handle<YieldTermStructure> &discountCurve,
         const Handle<SwaptionVolatilityStructure> &vol)
-        : BlackTypedSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
+        : BlackStyleSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
                                                           0.0) {}
 } // namespace QuantLib

--- a/QuantLib/ql/pricingengines/swaption/blackswaptionengine.cpp
+++ b/QuantLib/ql/pricingengines/swaption/blackswaptionengine.cpp
@@ -5,6 +5,7 @@
  Copyright (C) 2006 Cristina Duminuco
  Copyright (C) 2001, 2002, 2003 Sadruddin Rejeb
  Copyright (C) 2006, 2007 StatPro Italia srl
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -21,131 +22,39 @@
 */
 
 #include <ql/pricingengines/swaption/blackswaptionengine.hpp>
-#include <ql/pricingengines/blackformula.hpp>
-#include <ql/termstructures/volatility/swaption/swaptionconstantvol.hpp>
-#include <ql/time/calendars/nullcalendar.hpp>
-
-#include <ql/pricingengines/swap/discountingswapengine.hpp>
-#include <ql/indexes/iborindex.hpp>
-#include <ql/cashflows/fixedratecoupon.hpp>
-#include <ql/cashflows/cashflows.hpp>
-#include <ql/exercise.hpp>
 
 namespace QuantLib {
 
-    BlackSwaptionEngine::BlackSwaptionEngine(
-                              const Handle<YieldTermStructure>& discountCurve,
-                              Volatility vol,
-                              const DayCounter& dc,
-                              Real displacement)
-    : discountCurve_(discountCurve),
-      vol_(boost::shared_ptr<SwaptionVolatilityStructure>(new
-          ConstantSwaptionVolatility(0, NullCalendar(), Following, vol, dc))),
-      displacement_(displacement) {
-        registerWith(discountCurve_);
-    }
-
-    BlackSwaptionEngine::BlackSwaptionEngine(
-                            const Handle<YieldTermStructure>& discountCurve,
-                            const Handle<Quote>& vol,
-                            const DayCounter& dc,
-                            Real displacement)
-    : discountCurve_(discountCurve),
-      vol_(boost::shared_ptr<SwaptionVolatilityStructure>(new
-          ConstantSwaptionVolatility(0, NullCalendar(), Following, vol, dc))),
-      displacement_(displacement) {
-        registerWith(discountCurve_);
-        registerWith(vol_);
-    }
-
-    BlackSwaptionEngine::BlackSwaptionEngine(
-                        const Handle<YieldTermStructure>& discountCurve,
-                        const Handle<SwaptionVolatilityStructure>& volatility,
+    BlackSwaptionEngine::BlackSwaptionEngine(const Handle<YieldTermStructure> &discountCurve,
+                        Volatility vol, const DayCounter &dc,
                         Real displacement)
-    : discountCurve_(discountCurve), vol_(volatility),
-      displacement_(displacement) {
-        registerWith(discountCurve_);
-        registerWith(vol_);
-    }
+        : BlackTypedSwaptionEngine<detail::Black76Spec>(discountCurve, vol, dc,
+                                                displacement) {}
+    BlackSwaptionEngine::BlackSwaptionEngine(const Handle<YieldTermStructure> &discountCurve,
+                        const Handle<Quote> &vol,
+                        const DayCounter &dc,
+                        Real displacement)
+        : BlackTypedSwaptionEngine<detail::Black76Spec>(discountCurve, vol, dc,
+                                                displacement) {}
+    BlackSwaptionEngine::BlackSwaptionEngine(const Handle<YieldTermStructure> &discountCurve,
+                        const Handle<SwaptionVolatilityStructure> &vol,
+                        Real displacement)
+        : BlackTypedSwaptionEngine<detail::Black76Spec>(discountCurve, vol,
+                                                displacement) {}
 
-    void BlackSwaptionEngine::calculate() const {
-        static const Spread basisPoint = 1.0e-4;
-
-        Date exerciseDate = arguments_.exercise->date(0);
-
-        // the part of the swap preceding exerciseDate should be truncated
-        // to avoid taking into account unwanted cashflows
-        VanillaSwap swap = *arguments_.swap;
-
-        Rate strike = swap.fixedRate();
-
-        // using the discounting curve
-        // swap.iborIndex() might be using a different forwarding curve
-        swap.setPricingEngine(boost::shared_ptr<PricingEngine>(new
-            DiscountingSwapEngine(discountCurve_, false)));
-        Rate atmForward = swap.fairRate();
-
-        // Volatilities are quoted for zero-spreaded swaps.
-        // Therefore, any spread on the floating leg must be removed
-        // with a corresponding correction on the fixed leg.
-        if (swap.spread()!=0.0) {
-            Spread correction = swap.spread() *
-                std::fabs(swap.floatingLegBPS()/swap.fixedLegBPS());
-            strike -= correction;
-            atmForward -= correction;
-            results_.additionalResults["spreadCorrection"] = correction;
-        } else {
-            results_.additionalResults["spreadCorrection"] = 0.0;
-        }
-        results_.additionalResults["strike"] = strike;
-        results_.additionalResults["atmForward"] = atmForward;
-
-        // using the discounting curve
-        swap.setPricingEngine(boost::shared_ptr<PricingEngine>(
-                           new DiscountingSwapEngine(discountCurve_, false)));
-        Real annuity;
-        switch(arguments_.settlementType) {
-          case Settlement::Physical: {
-              annuity = std::fabs(swap.fixedLegBPS())/basisPoint;
-              break;
-          }
-          case Settlement::Cash: {
-              const Leg& fixedLeg = swap.fixedLeg();
-              boost::shared_ptr<FixedRateCoupon> firstCoupon =
-                  boost::dynamic_pointer_cast<FixedRateCoupon>(fixedLeg[0]);
-              DayCounter dayCount = firstCoupon->dayCounter();
-              Real fixedLegCashBPS =
-                  CashFlows::bps(fixedLeg,
-                                 InterestRate(atmForward, dayCount, Compounded, Annual),
-                                 false, discountCurve_->referenceDate()) ;
-              annuity = std::fabs(fixedLegCashBPS/basisPoint);
-              break;
-          }
-          default:
-            QL_FAIL("unknown settlement type");
-        }
-        results_.additionalResults["annuity"] = annuity;
-
-        // the swap length calculation might be improved using the value date
-        // of the exercise date
-        Time swapLength =  vol_->swapLength(exerciseDate,
-                                                   arguments_.floatingPayDates.back());
-        results_.additionalResults["swapLength"] = swapLength;
-
-        Real variance = vol_->blackVariance(exerciseDate,
-                                                   swapLength,
-                                                   strike);
-        Real stdDev = std::sqrt(variance);
-        results_.additionalResults["stdDev"] = stdDev;
-        Option::Type w = (arguments_.type==VanillaSwap::Payer) ?
-                                                Option::Call : Option::Put;
-        results_.value = blackFormula(w, strike, atmForward, stdDev, annuity,
-                                                                displacement_);
-
-        Time exerciseTime = vol_->timeFromReference(exerciseDate);
-        results_.additionalResults["vega"] = std::sqrt(exerciseTime) *
-            blackFormulaStdDevDerivative(strike, atmForward, stdDev, annuity,
-                                                                displacement_);
-    }
-
-}
+    BachelierBlackSwaptionEngine::BachelierBlackSwaptionEngine(
+        const Handle<YieldTermStructure> &discountCurve, Volatility vol,
+        const DayCounter &dc)
+        : BlackTypedSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
+                                                          dc, 0.0) {}
+    BachelierBlackSwaptionEngine::BachelierBlackSwaptionEngine(
+        const Handle<YieldTermStructure> &discountCurve,
+        const Handle<Quote> &vol, const DayCounter &dc)
+        : BlackTypedSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
+                                                          dc, 0.0) {}
+    BachelierBlackSwaptionEngine::BachelierBlackSwaptionEngine(
+        const Handle<YieldTermStructure> &discountCurve,
+        const Handle<SwaptionVolatilityStructure> &vol)
+        : BlackTypedSwaptionEngine<detail::BachelierSpec>(discountCurve, vol,
+                                                          0.0) {}
+} // namespace QuantLib

--- a/QuantLib/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/QuantLib/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -42,20 +42,20 @@ namespace QuantLib {
 
     class Quote;
 
-    /*! Generic Black-typed-formula swaption engine
+    /*! Generic Black-style-formula swaption engine
         This is the base class for the Black and Bachelier swaption engines */
     template<class Spec>
-    class BlackTypedSwaptionEngine : public Swaption::engine {
+    class BlackStyleSwaptionEngine : public Swaption::engine {
       public:
-        BlackTypedSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+        BlackStyleSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
                             Volatility vol,
                             const DayCounter& dc = Actual365Fixed(),
                             Real displacement = 0.0);
-        BlackTypedSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+        BlackStyleSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
                             const Handle<Quote>& vol,
                             const DayCounter& dc = Actual365Fixed(),
                             Real displacement = 0.0);
-        BlackTypedSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+        BlackStyleSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
                             const Handle<SwaptionVolatilityStructure>& vol,
                             Real displacement = 0.0);
         void calculate() const;
@@ -117,7 +117,7 @@ namespace QuantLib {
     */
 
     class BlackSwaptionEngine
-        : public BlackTypedSwaptionEngine<detail::Black76Spec> {
+        : public BlackStyleSwaptionEngine<detail::Black76Spec> {
       public:
         BlackSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
                             Volatility vol,
@@ -141,7 +141,7 @@ namespace QuantLib {
     */
 
     class BachelierBlackSwaptionEngine
-        : public BlackTypedSwaptionEngine<detail::BachelierSpec> {
+        : public BlackStyleSwaptionEngine<detail::BachelierSpec> {
       public:
         BachelierBlackSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
                             Volatility vol,
@@ -156,7 +156,7 @@ namespace QuantLib {
     // implementation
 
     template<class Spec>
-    BlackTypedSwaptionEngine<Spec>::BlackTypedSwaptionEngine(
+    BlackStyleSwaptionEngine<Spec>::BlackStyleSwaptionEngine(
         const Handle<YieldTermStructure> &discountCurve, Volatility vol,
         const DayCounter &dc, Real displacement)
         : discountCurve_(discountCurve),
@@ -168,7 +168,7 @@ namespace QuantLib {
     }
 
     template<class Spec>
-    BlackTypedSwaptionEngine<Spec>::BlackTypedSwaptionEngine(
+    BlackStyleSwaptionEngine<Spec>::BlackStyleSwaptionEngine(
         const Handle<YieldTermStructure> &discountCurve,
         const Handle<Quote> &vol, const DayCounter &dc, Real displacement)
         : discountCurve_(discountCurve),
@@ -181,7 +181,7 @@ namespace QuantLib {
     }
 
     template<class Spec>
-    BlackTypedSwaptionEngine<Spec>::BlackTypedSwaptionEngine(
+    BlackStyleSwaptionEngine<Spec>::BlackStyleSwaptionEngine(
         const Handle<YieldTermStructure> &discountCurve,
         const Handle<SwaptionVolatilityStructure> &volatility,
         Real displacement)
@@ -192,7 +192,7 @@ namespace QuantLib {
     }
 
     template<class Spec>
-    void BlackTypedSwaptionEngine<Spec>::calculate() const {
+    void BlackStyleSwaptionEngine<Spec>::calculate() const {
         static const Spread basisPoint = 1.0e-4;
 
         Date exerciseDate = arguments_.exercise->date(0);

--- a/QuantLib/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/QuantLib/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -4,6 +4,7 @@
  Copyright (C) 2007 Ferdinando Ametrano
  Copyright (C) 2001, 2002, 2003 Sadruddin Rejeb
  Copyright (C) 2006 StatPro Italia srl
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -28,18 +29,95 @@
 
 #include <ql/instruments/swaption.hpp>
 #include <ql/termstructures/volatility/swaption/swaptionvolstructure.hpp>
+#include <ql/pricingengines/blackformula.hpp>
+#include <ql/termstructures/volatility/swaption/swaptionconstantvol.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/indexes/iborindex.hpp>
+#include <ql/cashflows/fixedratecoupon.hpp>
+#include <ql/cashflows/cashflows.hpp>
+#include <ql/exercise.hpp>
 
 namespace QuantLib {
 
     class Quote;
 
-    //! Black-formula swaption engine
+    /*! Generic Black-typed-formula swaption engine
+        This is the base class for the Black and Bachelier swaption engines */
+    template<class Spec>
+    class BlackTypedSwaptionEngine : public Swaption::engine {
+      public:
+        BlackTypedSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+                            Volatility vol,
+                            const DayCounter& dc = Actual365Fixed(),
+                            Real displacement = 0.0);
+        BlackTypedSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+                            const Handle<Quote>& vol,
+                            const DayCounter& dc = Actual365Fixed(),
+                            Real displacement = 0.0);
+        BlackTypedSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+                            const Handle<SwaptionVolatilityStructure>& vol,
+                            Real displacement = 0.0);
+        void calculate() const;
+        Handle<YieldTermStructure> termStructure() { return discountCurve_; }
+        Handle<SwaptionVolatilityStructure> volatility() { return vol_; }
+
+      private:
+        Handle<YieldTermStructure> discountCurve_;
+        Handle<SwaptionVolatilityStructure> vol_;
+
+      protected:
+        Real displacement_;
+    };
+
+    namespace detail {
+
+    // shifted lognormal type engine
+    struct Black76Spec {
+        const VolatilityType type = ShiftedLognormal;
+        Real value(const Option::Type type, const Real strike,
+                   const Real atmForward, const Real stdDev, const Real annuity,
+                   const Real displacement) {
+            return blackFormula(type, strike, atmForward, stdDev, annuity,
+                                displacement);
+        }
+        Real vega(const Real strike, const Real atmForward, const Real stdDev,
+                  const Real exerciseTime, const Real annuity,
+                  const Real displacement) {
+            return std::sqrt(exerciseTime) *
+                   blackFormulaStdDevDerivative(strike, atmForward, stdDev,
+                                                annuity, displacement);
+        }
+    };
+
+    // normal type engine
+    struct BachelierSpec {
+        const VolatilityType type = Normal;
+        Real value(const Option::Type type, const Real strike,
+                   const Real atmForward, const Real stdDev, const Real annuity,
+                   const Real) {
+            return bachelierBlackFormula(type, strike, atmForward, stdDev,
+                                         annuity);
+        }
+        Real vega(const Real strike, const Real atmForward, const Real stdDev,
+                  const Real exerciseTime, const Real annuity, const Real) {
+            return std::sqrt(exerciseTime) *
+                   bachelierBlackFormulaStdDevDerivative(
+                       strike, atmForward, stdDev, annuity);
+        }
+    };
+
+    } // anonymous namespace
+
+    //! Shifted Lognpormal Black-formula swaption engine
     /*! \ingroup swaptionengines
 
         \warning The engine assumes that the exercise date equals the
                  start date of the passed swap.
     */
-    class BlackSwaptionEngine : public Swaption::engine {
+
+    class BlackSwaptionEngine
+        : public BlackTypedSwaptionEngine<detail::Black76Spec> {
       public:
         BlackSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
                             Volatility vol,
@@ -52,16 +130,147 @@ namespace QuantLib {
         BlackSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
                             const Handle<SwaptionVolatilityStructure>& vol,
                             Real displacement = 0.0);
-        void calculate() const;
-        Handle<YieldTermStructure> termStructure() { return discountCurve_; }
-        Handle<SwaptionVolatilityStructure> volatility() { return vol_; }
         Real displacement() { return displacement_; }
-      private:
-        Handle<YieldTermStructure> discountCurve_;
-        Handle<SwaptionVolatilityStructure> vol_;
-        Real displacement_;
     };
 
-}
+    //! Normal Bachelier-formula swaption engine
+    /*! \ingroup swaptionengines
+
+        \warning The engine assumes that the exercise date equals the
+                 start date of the passed swap.
+    */
+
+    class BachelierBlackSwaptionEngine
+        : public BlackTypedSwaptionEngine<detail::BachelierSpec> {
+      public:
+        BachelierBlackSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+                            Volatility vol,
+                            const DayCounter& dc = Actual365Fixed());
+        BachelierBlackSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+                            const Handle<Quote>& vol,
+                            const DayCounter& dc = Actual365Fixed());
+        BachelierBlackSwaptionEngine(const Handle<YieldTermStructure>& discountCurve,
+                            const Handle<SwaptionVolatilityStructure>& vol);
+    };
+
+    // implementation
+
+    template<class Spec>
+    BlackTypedSwaptionEngine<Spec>::BlackTypedSwaptionEngine(
+        const Handle<YieldTermStructure> &discountCurve, Volatility vol,
+        const DayCounter &dc, Real displacement)
+        : discountCurve_(discountCurve),
+          vol_(boost::shared_ptr<SwaptionVolatilityStructure>(
+              new ConstantSwaptionVolatility(0, NullCalendar(), Following, vol,
+                                             dc, Spec().type, displacement))),
+          displacement_(displacement) {
+        registerWith(discountCurve_);
+    }
+
+    template<class Spec>
+    BlackTypedSwaptionEngine<Spec>::BlackTypedSwaptionEngine(
+        const Handle<YieldTermStructure> &discountCurve,
+        const Handle<Quote> &vol, const DayCounter &dc, Real displacement)
+        : discountCurve_(discountCurve),
+          vol_(boost::shared_ptr<SwaptionVolatilityStructure>(
+              new ConstantSwaptionVolatility(0, NullCalendar(), Following, vol,
+                                             dc, Spec().type, displacement))),
+          displacement_(displacement) {
+        registerWith(discountCurve_);
+        registerWith(vol_);
+    }
+
+    template<class Spec>
+    BlackTypedSwaptionEngine<Spec>::BlackTypedSwaptionEngine(
+        const Handle<YieldTermStructure> &discountCurve,
+        const Handle<SwaptionVolatilityStructure> &volatility,
+        Real displacement)
+        : discountCurve_(discountCurve), vol_(volatility),
+          displacement_(displacement) {
+        registerWith(discountCurve_);
+        registerWith(vol_);
+    }
+
+    template<class Spec>
+    void BlackTypedSwaptionEngine<Spec>::calculate() const {
+        static const Spread basisPoint = 1.0e-4;
+
+        Date exerciseDate = arguments_.exercise->date(0);
+
+        // the part of the swap preceding exerciseDate should be truncated
+        // to avoid taking into account unwanted cashflows
+        VanillaSwap swap = *arguments_.swap;
+
+        Rate strike = swap.fixedRate();
+
+        // using the discounting curve
+        // swap.iborIndex() might be using a different forwarding curve
+        swap.setPricingEngine(boost::shared_ptr<PricingEngine>(new
+            DiscountingSwapEngine(discountCurve_, false)));
+        Rate atmForward = swap.fairRate();
+
+        // Volatilities are quoted for zero-spreaded swaps.
+        // Therefore, any spread on the floating leg must be removed
+        // with a corresponding correction on the fixed leg.
+        if (swap.spread()!=0.0) {
+            Spread correction = swap.spread() *
+                std::fabs(swap.floatingLegBPS()/swap.fixedLegBPS());
+            strike -= correction;
+            atmForward -= correction;
+            results_.additionalResults["spreadCorrection"] = correction;
+        } else {
+            results_.additionalResults["spreadCorrection"] = 0.0;
+        }
+        results_.additionalResults["strike"] = strike;
+        results_.additionalResults["atmForward"] = atmForward;
+
+        // using the discounting curve
+        swap.setPricingEngine(boost::shared_ptr<PricingEngine>(
+                           new DiscountingSwapEngine(discountCurve_, false)));
+        Real annuity;
+        switch(arguments_.settlementType) {
+          case Settlement::Physical: {
+              annuity = std::fabs(swap.fixedLegBPS())/basisPoint;
+              break;
+          }
+          case Settlement::Cash: {
+              const Leg& fixedLeg = swap.fixedLeg();
+              boost::shared_ptr<FixedRateCoupon> firstCoupon =
+                  boost::dynamic_pointer_cast<FixedRateCoupon>(fixedLeg[0]);
+              DayCounter dayCount = firstCoupon->dayCounter();
+              Real fixedLegCashBPS =
+                  CashFlows::bps(fixedLeg,
+                                 InterestRate(atmForward, dayCount, Compounded, Annual),
+                                 false, discountCurve_->referenceDate()) ;
+              annuity = std::fabs(fixedLegCashBPS/basisPoint);
+              break;
+          }
+          default:
+            QL_FAIL("unknown settlement type");
+        }
+        results_.additionalResults["annuity"] = annuity;
+
+        // the swap length calculation might be improved using the value date
+        // of the exercise date
+        Time swapLength =  vol_->swapLength(exerciseDate,
+                                                   arguments_.floatingPayDates.back());
+        results_.additionalResults["swapLength"] = swapLength;
+
+        Real variance = vol_->blackVariance(exerciseDate,
+                                                   swapLength,
+                                                   strike);
+        Real stdDev = std::sqrt(variance);
+        results_.additionalResults["stdDev"] = stdDev;
+        Option::Type w = (arguments_.type==VanillaSwap::Payer) ?
+                                                Option::Call : Option::Put;
+        results_.value = Spec().value(w, strike, atmForward, stdDev, annuity,
+                                                                displacement_);
+
+        Time exerciseTime = vol_->timeFromReference(exerciseDate);
+        results_.additionalResults["vega"] = Spec().vega(
+            strike, atmForward, stdDev, exerciseTime, annuity, displacement_);
+    }
+
+} // namespace QuantLib
 
 #endif

--- a/QuantLib/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/QuantLib/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -74,7 +74,7 @@ namespace QuantLib {
 
     // shifted lognormal type engine
     struct Black76Spec {
-        const VolatilityType type = ShiftedLognormal;
+        static const VolatilityType type = ShiftedLognormal;
         Real value(const Option::Type type, const Real strike,
                    const Real atmForward, const Real stdDev, const Real annuity,
                    const Real displacement) {
@@ -92,7 +92,7 @@ namespace QuantLib {
 
     // normal type engine
     struct BachelierSpec {
-        const VolatilityType type = Normal;
+        static const VolatilityType type = Normal;
         Real value(const Option::Type type, const Real strike,
                    const Real atmForward, const Real stdDev, const Real annuity,
                    const Real) {

--- a/QuantLib/ql/termstructures/volatility/flatsmilesection.cpp
+++ b/QuantLib/ql/termstructures/volatility/flatsmilesection.cpp
@@ -29,16 +29,18 @@ namespace QuantLib {
                                        const DayCounter& dc,
                                        const Date& referenceDate,
                                        Real atmLevel,
+                                       VolatilityType type,
                                        Real shift)
-        : SmileSection(d, dc, referenceDate, ShiftedLognormal, shift),
+        : SmileSection(d, dc, referenceDate, type, shift),
       vol_(vol), atmLevel_(atmLevel) {}
 
     FlatSmileSection::FlatSmileSection(Time exerciseTime,
                                        Volatility vol,
                                        const DayCounter& dc,
                                        Real atmLevel,
+                                       VolatilityType type,
                                        Real shift)
-        : SmileSection(exerciseTime, dc, ShiftedLognormal, shift),
+        : SmileSection(exerciseTime, dc, type, shift),
       vol_(vol), atmLevel_(atmLevel) {}
 
 }

--- a/QuantLib/ql/termstructures/volatility/flatsmilesection.hpp
+++ b/QuantLib/ql/termstructures/volatility/flatsmilesection.hpp
@@ -38,11 +38,13 @@ namespace QuantLib {
                          const DayCounter& dc,
                          const Date& referenceDate = Date(),
                          Real atmLevel = Null<Rate>(),
+                         VolatilityType type = ShiftedLognormal,
                          Real shift = 0.0);
         FlatSmileSection(Time exerciseTime,
                          Volatility vol,
                          const DayCounter& dc,
                          Real atmLevel = Null<Rate>(),
+                         VolatilityType type = ShiftedLognormal,
                          Real shift = 0.0);
         //! \name SmileSection interface
         //@{

--- a/QuantLib/ql/termstructures/volatility/interpolatedsmilesection.hpp
+++ b/QuantLib/ql/termstructures/volatility/interpolatedsmilesection.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2006 Ferdinando Ametrano
  Copyright (C) 2006 François du Vignaud
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -44,6 +45,7 @@ namespace QuantLib {
                            const Handle<Quote>& atmLevel,
                            const Interpolator& interpolator = Interpolator(),
                            const DayCounter& dc = Actual365Fixed(),
+                           const VolatilityType type = ShiftedLognormal,
                            const Real shift = 0.0);
         InterpolatedSmileSection(
                            Time expiryTime,
@@ -52,6 +54,7 @@ namespace QuantLib {
                            Real atmLevel,
                            const Interpolator& interpolator = Interpolator(),
                            const DayCounter& dc = Actual365Fixed(),
+                           const VolatilityType type = ShiftedLognormal,
                            const Real shift = 0.0);
         InterpolatedSmileSection(
                            const Date& d,
@@ -61,6 +64,7 @@ namespace QuantLib {
                            const DayCounter& dc = Actual365Fixed(),
                            const Interpolator& interpolator = Interpolator(),
                            const Date& referenceDate = Date(),
+                           const VolatilityType type = ShiftedLognormal,
                            const Real shift = 0.0);
         InterpolatedSmileSection(
                            const Date& d,
@@ -70,6 +74,7 @@ namespace QuantLib {
                            const DayCounter& dc = Actual365Fixed(),
                            const Interpolator& interpolator = Interpolator(),
                            const Date& referenceDate = Date(),
+                           const VolatilityType type = ShiftedLognormal,
                            const Real shift = 0.0);
         void performCalculations() const;
         Real varianceImpl(Rate strike) const;
@@ -96,8 +101,9 @@ namespace QuantLib {
                                const Handle<Quote>& atmLevel,
                                const Interpolator& interpolator,
                                const DayCounter& dc,
+                               const VolatilityType type,
                                const Real shift)
-    : SmileSection(timeToExpiry, dc, ShiftedLognormal, shift),
+    : SmileSection(timeToExpiry, dc, type, shift),
       exerciseTimeSquareRoot_(std::sqrt(exerciseTime())), strikes_(strikes),
       stdDevHandles_(stdDevHandles), atmLevel_(atmLevel),
       vols_(stdDevHandles.size())
@@ -119,8 +125,9 @@ namespace QuantLib {
                                 Real atmLevel,
                                 const Interpolator& interpolator,
                                 const DayCounter& dc,
+                                const VolatilityType type,
                                 const Real shift)
-    : SmileSection(timeToExpiry, dc, ShiftedLognormal, shift),
+    : SmileSection(timeToExpiry, dc, type, shift),
       exerciseTimeSquareRoot_(std::sqrt(exerciseTime())), strikes_(strikes),
       stdDevHandles_(stdDevs.size()), vols_(stdDevs.size())
     {
@@ -146,8 +153,9 @@ namespace QuantLib {
                            const DayCounter& dc,
                            const Interpolator& interpolator,
                            const Date& referenceDate,
+                           const VolatilityType type,
                            const Real shift)
-    : SmileSection(d, dc, referenceDate, ShiftedLognormal, shift),
+    : SmileSection(d, dc, referenceDate, type, shift),
       exerciseTimeSquareRoot_(std::sqrt(exerciseTime())), strikes_(strikes),
       stdDevHandles_(stdDevHandles), atmLevel_(atmLevel), vols_(stdDevHandles.size())
     {
@@ -169,8 +177,9 @@ namespace QuantLib {
                            const DayCounter& dc,
                            const Interpolator& interpolator,
                            const Date& referenceDate,
+                           const VolatilityType type,
                            const Real shift)
-    : SmileSection(d, dc, referenceDate, ShiftedLognormal, shift),
+    : SmileSection(d, dc, referenceDate, type, shift),
       exerciseTimeSquareRoot_(std::sqrt(exerciseTime())), strikes_(strikes),
       stdDevHandles_(stdDevs.size()), vols_(stdDevs.size())
     {

--- a/QuantLib/ql/termstructures/volatility/swaption/spreadedswaptionvol.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/spreadedswaptionvol.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2008 Ferdinando Ametrano
  Copyright (C) 2007 Giorgio Facchinetti
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -54,6 +55,8 @@ namespace QuantLib {
         //@{
         const Period& maxSwapTenor() const;
         //@}
+        Real shift(Time optionTime, Time swapLength) const;
+        VolatilityType volatilityType() const;
       protected:
         //! \name SwaptionVolatilityStructure interface
         //@{
@@ -110,6 +113,17 @@ namespace QuantLib {
     inline const Period& SpreadedSwaptionVolatility::maxSwapTenor() const {
         return baseVol_->maxSwapTenor();
     }
+
+    inline Real SpreadedSwaptionVolatility::shift(Time optionTime,
+                                                  Time swapLength) const {
+        return baseVol_->shift(optionTime, swapLength);
+    }
+
+    inline VolatilityType SpreadedSwaptionVolatility::volatilityType() const {
+        return baseVol_->volatilityType();
+    }
+
+
 
 }
 

--- a/QuantLib/ql/termstructures/volatility/swaption/spreadedswaptionvol.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/spreadedswaptionvol.hpp
@@ -55,7 +55,6 @@ namespace QuantLib {
         //@{
         const Period& maxSwapTenor() const;
         //@}
-        Real shift(Time optionTime, Time swapLength) const;
         VolatilityType volatilityType() const;
       protected:
         //! \name SwaptionVolatilityStructure interface
@@ -72,6 +71,7 @@ namespace QuantLib {
         Volatility volatilityImpl(Time optionTime,
                                   Time swapLength,
                                   Rate strike) const;
+        Real shiftImpl(Time optionTime, Time swapLength) const;
         //@}
       private:
         const Handle<SwaptionVolatilityStructure> baseVol_;
@@ -114,9 +114,9 @@ namespace QuantLib {
         return baseVol_->maxSwapTenor();
     }
 
-    inline Real SpreadedSwaptionVolatility::shift(Time optionTime,
+    inline Real SpreadedSwaptionVolatility::shiftImpl(Time optionTime,
                                                   Time swapLength) const {
-        return baseVol_->shift(optionTime, swapLength);
+        return baseVol_->shift(optionTime, swapLength, true);
     }
 
     inline VolatilityType SpreadedSwaptionVolatility::volatilityType() const {

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionconstantvol.cpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionconstantvol.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2008 Ferdinando Ametrano
  Copyright (C) 2006, 2007 StatPro Italia srl
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -30,9 +31,11 @@ namespace QuantLib {
                                                     const Calendar& cal,
                                                     BusinessDayConvention bdc,
                                                     const Handle<Quote>& vol,
-                                                    const DayCounter& dc)
+                                                    const DayCounter& dc,
+                                                    const VolatilityType type,
+                                                    const Real shift)
     : SwaptionVolatilityStructure(settlementDays, cal, bdc, dc),
-      volatility_(vol), maxSwapTenor_(100*Years) {
+      volatility_(vol), maxSwapTenor_(100*Years), volatilityType_(type), shift_(shift) {
         registerWith(volatility_);
     }
 
@@ -42,9 +45,11 @@ namespace QuantLib {
                                                     const Calendar& cal,
                                                     BusinessDayConvention bdc,
                                                     const Handle<Quote>& vol,
-                                                    const DayCounter& dc)
+                                                    const DayCounter& dc,
+                                                    const VolatilityType type,
+                                                    const Real shift)
     : SwaptionVolatilityStructure(referenceDate, cal, bdc, dc),
-      volatility_(vol), maxSwapTenor_(100*Years) {
+      volatility_(vol), maxSwapTenor_(100*Years), volatilityType_(type), shift_(shift) {
         registerWith(volatility_);
     }
 
@@ -54,10 +59,12 @@ namespace QuantLib {
                                                     const Calendar& cal,
                                                     BusinessDayConvention bdc,
                                                     Volatility vol,
-                                                    const DayCounter& dc)
+                                                    const DayCounter& dc,
+                                                    const VolatilityType type,
+                                                    const Real shift)
     : SwaptionVolatilityStructure(settlementDays, cal, bdc, dc),
       volatility_(boost::shared_ptr<Quote>(new SimpleQuote(vol))),
-      maxSwapTenor_(100*Years) {}
+      maxSwapTenor_(100*Years), volatilityType_(type), shift_(shift) {}
 
     // fixed reference date, fixed market data
     ConstantSwaptionVolatility::ConstantSwaptionVolatility(
@@ -65,25 +72,29 @@ namespace QuantLib {
                                                     const Calendar& cal,
                                                     BusinessDayConvention bdc,
                                                     Volatility vol,
-                                                    const DayCounter& dc)
+                                                    const DayCounter& dc,
+                                                    const VolatilityType type,
+                                                    const Real shift)
     : SwaptionVolatilityStructure(referenceDate, cal, bdc, dc),
       volatility_(boost::shared_ptr<Quote>(new SimpleQuote(vol))),
-      maxSwapTenor_(100*Years) {}
+      maxSwapTenor_(100*Years), volatilityType_(type), shift_(shift) {}
 
     boost::shared_ptr<SmileSection>
     ConstantSwaptionVolatility::smileSectionImpl(const Date& d,
                                                  const Period&) const {
         Volatility atmVol = volatility_->value();
-        return boost::shared_ptr<SmileSection>(new
-            FlatSmileSection(d, atmVol, dayCounter(), referenceDate()));
+        return boost::shared_ptr<SmileSection>(
+            new FlatSmileSection(d, atmVol, dayCounter(), referenceDate(),
+                                 Null<Rate>(), volatilityType_, shift_));
     }
 
     boost::shared_ptr<SmileSection>
     ConstantSwaptionVolatility::smileSectionImpl(Time optionTime,
                                                  Time) const {
         Volatility atmVol = volatility_->value();
-        return boost::shared_ptr<SmileSection>(new
-            FlatSmileSection(optionTime, atmVol, dayCounter()));
+        return boost::shared_ptr<SmileSection>(
+            new FlatSmileSection(optionTime, atmVol, dayCounter(), Null<Rate>(),
+                                 volatilityType_, shift_));
     }
 
     Volatility ConstantSwaptionVolatility::volatilityImpl(const Date&,

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionconstantvol.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionconstantvol.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2008 Ferdinando Ametrano
  Copyright (C) 2006, 2007 StatPro Italia srl
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -40,25 +41,33 @@ namespace QuantLib {
                                    const Calendar& cal,
                                    BusinessDayConvention bdc,
                                    const Handle<Quote>& volatility,
-                                   const DayCounter& dc);
+                                   const DayCounter& dc,
+                                   const VolatilityType type = ShiftedLognormal,
+                                   const Real shift = 0.0);
         //! fixed reference date, floating market data
         ConstantSwaptionVolatility(const Date& referenceDate,
                                    const Calendar& cal,
                                    BusinessDayConvention bdc,
                                    const Handle<Quote>& volatility,
-                                   const DayCounter& dc);
+                                   const DayCounter& dc,
+                                   const VolatilityType type = ShiftedLognormal,
+                                   const Real shift = 0.0);
         //! floating reference date, fixed market data
         ConstantSwaptionVolatility(Natural settlementDays,
                                    const Calendar& cal,
                                    BusinessDayConvention bdc,
                                    Volatility volatility,
-                                   const DayCounter& dc);
+                                   const DayCounter& dc,
+                                   const VolatilityType type = ShiftedLognormal,
+                                   const Real shift = 0.0);
         //! fixed reference date, fixed market data
         ConstantSwaptionVolatility(const Date& referenceDate,
                                    const Calendar& cal,
                                    BusinessDayConvention bdc,
                                    Volatility volatility,
-                                   const DayCounter& dc);
+                                   const DayCounter& dc,
+                                   const VolatilityType type = ShiftedLognormal,
+                                   const Real shift = 0.0);
         //! \name TermStructure interface
         //@{
         Date maxDate() const;
@@ -72,6 +81,15 @@ namespace QuantLib {
         //@{
         const Period& maxSwapTenor() const;
         //@}
+        Real shift(Time optionTime, Time swapLength) {
+            // consistency check
+            SwaptionVolatilityStructure::shift(optionTime, swapLength);
+            return shift_;
+        }
+        //! volatility type
+        virtual VolatilityType volatilityType() const {
+            return volatilityType_;
+        }
       protected:
         boost::shared_ptr<SmileSection> smileSectionImpl(const Date&,
                                                          const Period&) const;
@@ -86,6 +104,8 @@ namespace QuantLib {
       private:
         Handle<Quote> volatility_;
         Period maxSwapTenor_;
+        VolatilityType volatilityType_;
+        Real shift_;
     };
 
 

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionconstantvol.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionconstantvol.hpp
@@ -81,15 +81,8 @@ namespace QuantLib {
         //@{
         const Period& maxSwapTenor() const;
         //@}
-        Real shift(Time optionTime, Time swapLength) {
-            // consistency check
-            SwaptionVolatilityStructure::shift(optionTime, swapLength);
-            return shift_;
-        }
         //! volatility type
-        virtual VolatilityType volatilityType() const {
-            return volatilityType_;
-        }
+        VolatilityType volatilityType() const;
       protected:
         boost::shared_ptr<SmileSection> smileSectionImpl(const Date&,
                                                          const Period&) const;
@@ -101,6 +94,7 @@ namespace QuantLib {
         Volatility volatilityImpl(Time,
                                   Time,
                                   Rate) const;
+        Real shiftImpl(Time optionTime, Time swapLength) const;
       private:
         Handle<Quote> volatility_;
         Period maxSwapTenor_;
@@ -125,6 +119,16 @@ namespace QuantLib {
 
     inline const Period& ConstantSwaptionVolatility::maxSwapTenor() const {
         return maxSwapTenor_;
+    }
+
+    inline VolatilityType ConstantSwaptionVolatility::volatilityType() const {
+        return volatilityType_;
+    }
+
+    inline Real ConstantSwaptionVolatility::shiftImpl(Time optionTime, Time swapLength) const {
+        // consistency check
+        SwaptionVolatilityStructure::shiftImpl(optionTime, swapLength);
+        return shift_;
     }
 
 }

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2006 Ferdinando Ametrano
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -92,6 +93,9 @@ namespace QuantLib {
         //@}
         Real shift(Time optionTime, Time swapLength) const {
             return atmVol_->shift(optionTime,swapLength);
+        }
+        VolatilityType volatilityType() const {
+            return atmVol_->volatilityType();
         }
       protected:
         void registerWithVolatilitySpread();

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube.hpp
@@ -91,12 +91,7 @@ namespace QuantLib {
             SwaptionVolatilityDiscrete::performCalculations();
         }
         //@}
-        Real shift(Time optionTime, Time swapLength) const {
-            return atmVol_->shift(optionTime,swapLength);
-        }
-        VolatilityType volatilityType() const {
-            return atmVol_->volatilityType();
-        }
+        VolatilityType volatilityType() const;
       protected:
         void registerWithVolatilitySpread();
         virtual Size requiredNumberOfStrikes() const { return 2; }
@@ -106,6 +101,7 @@ namespace QuantLib {
         Volatility volatilityImpl(const Date& optionDate,
                                   const Period& swapTenor,
                                   Rate strike) const;
+        Real shiftImpl(Time optionTime, Time swapLength) const;
         Handle<SwaptionVolatilityStructure> atmVol_;
         Size nStrikes_;
         std::vector<Spread> strikeSpreads_;
@@ -117,6 +113,10 @@ namespace QuantLib {
     };
 
     // inline
+
+    inline VolatilityType SwaptionVolatilityCube::volatilityType() const {
+        return atmVol_->volatilityType();
+    }
 
     inline Volatility SwaptionVolatilityCube::volatilityImpl(
                                                         Time optionTime,
@@ -132,6 +132,10 @@ namespace QuantLib {
         return smileSectionImpl(optionDate, swapTenor)->volatility(strike);
     }
 
+    inline Real SwaptionVolatilityCube::shiftImpl(Time optionTime,
+                                                  Time swapLength) const {
+        return atmVol_->shift(optionTime, swapLength);
+    }
 }
 
 #endif

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
@@ -2,7 +2,7 @@
 
 /*
  Copyright (C) 2006, 2007 Giorgio Facchinetti
- Copyright (C) 2014 Peter Caspers
+ Copyright (C) 2014, 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -241,6 +241,11 @@ namespace QuantLib {
           optMethod_(optMethod),
           useMaxError_(useMaxError), maxGuesses_(maxGuesses),
           backwardFlat_(backwardFlat), cutoffStrike_(cutoffStrike) {
+
+        // the current implementations are all lognormal, if we have
+        // a normal one, we can move this check to the implementing classes
+        QL_REQUIRE(atmVolStructure->volatilityType() == ShiftedLognormal,
+                   "vol cubes of type 1 require a lognormal atm surface");
 
         if (maxErrorTolerance != Null<Rate>()) {
             maxErrorTolerance_ = maxErrorTolerance;

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube2.cpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolcube2.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2006 Ferdinando Ametrano
  Copyright (C) 2006 Katiuscia Manzoni
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -108,6 +109,7 @@ namespace QuantLib {
                                              atmForward,
                                              Linear(),
                                              Actual365Fixed(),
+                                             volatilityType(),
                                              shift));
     }
 }

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolmatrix.cpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolmatrix.cpp
@@ -42,11 +42,12 @@ namespace QuantLib {
                     const std::vector<std::vector<Handle<Quote> > >& vols,
                     const DayCounter& dc,
                     const bool flatExtrapolation,
+                    const VolatilityType type,
                     const std::vector<std::vector<Real> >& shifts)
     : SwaptionVolatilityDiscrete(optionT, swapT, 0, cal, bdc, dc),
       volHandles_(vols), shiftValues_(shifts),
       volatilities_(vols.size(), vols.front().size()),
-      shifts_(vols.size(), vols.front().size(), 0.0) {
+      shifts_(vols.size(), vols.front().size(), 0.0), volatilityType_(type) {
         checkInputs(volatilities_.rows(), volatilities_.columns(),
                     shifts.size(), shifts.size() == 0 ? 0 : shifts.front().size());
         registerWithMarketData();
@@ -79,11 +80,12 @@ namespace QuantLib {
                     const std::vector<std::vector<Handle<Quote> > >& vols,
                     const DayCounter& dc,
                     const bool flatExtrapolation,
+                    const VolatilityType type,
                     const std::vector<std::vector<Real> >& shifts)
     : SwaptionVolatilityDiscrete(optionT, swapT, refDate, cal, bdc, dc),
       volHandles_(vols), shiftValues_(shifts),
       volatilities_(vols.size(), vols.front().size()),
-      shifts_(vols.size(), vols.front().size(), 0.0) {
+      shifts_(vols.size(), vols.front().size(), 0.0), volatilityType_(type) {
         checkInputs(volatilities_.rows(), volatilities_.columns(),
                     shifts.size(), shifts.size() == 0 ? 0 : shifts.front().size());
         registerWithMarketData();
@@ -115,11 +117,12 @@ namespace QuantLib {
                         const Matrix& vols,
                         const DayCounter& dc,
                         const bool flatExtrapolation,
+                        const VolatilityType type,
                         const Matrix& shifts)
     : SwaptionVolatilityDiscrete(optionT, swapT, 0, cal, bdc, dc),
       volHandles_(vols.rows()), shiftValues_(vols.rows()),
       volatilities_(vols.rows(), vols.columns()),
-      shifts_(vols.rows(), vols.columns(), 0.0) {
+      shifts_(vols.rows(), vols.columns(), 0.0), volatilityType_(type) {
 
         checkInputs(vols.rows(), vols.columns(), shifts.rows(), shifts.columns());
 
@@ -163,11 +166,12 @@ namespace QuantLib {
                         const Matrix& vols,
                         const DayCounter& dc,
                         const bool flatExtrapolation,
+                        const VolatilityType type,
                         const Matrix& shifts)
     : SwaptionVolatilityDiscrete(optionT, swapT, refDate, cal, bdc, dc),
       volHandles_(vols.rows()), shiftValues_(vols.rows()),
       volatilities_(vols.rows(), vols.columns()),
-      shifts_(shifts.rows(), shifts.columns(), 0.0) {
+      shifts_(shifts.rows(), shifts.columns(), 0.0), volatilityType_(type) {
 
         checkInputs(vols.rows(), vols.columns(), shifts.rows(), shifts.columns());
 
@@ -209,11 +213,12 @@ namespace QuantLib {
                     const Matrix& vols,
                     const DayCounter& dc,
                     const bool flatExtrapolation,
+                    const VolatilityType type,
                     const Matrix& shifts)
     : SwaptionVolatilityDiscrete(optionDates, swapT, today, Calendar(), Following, dc),
       volHandles_(vols.rows()), shiftValues_(vols.rows()),
       volatilities_(vols.rows(), vols.columns()),
-      shifts_(shifts.rows(),shifts.columns(),0.0) {
+      shifts_(shifts.rows(),shifts.columns(),0.0), volatilityType_(type) {
 
         checkInputs(vols.rows(), vols.columns(), shifts.rows(), shifts.columns());
 
@@ -315,8 +320,9 @@ namespace QuantLib {
         // dummy strike
         Volatility atmVol = volatilityImpl(optionTime, swapLength, 0.05);
         Real shift = interpolationShifts_(optionTime, swapLength,true);
-        return boost::shared_ptr<SmileSection>(new FlatSmileSection(
-            optionTime, atmVol, dayCounter(), Null<Real>(), shift));
+        return boost::shared_ptr<SmileSection>(
+            new FlatSmileSection(optionTime, atmVol, dayCounter(), Null<Real>(),
+                                 volatilityType(), shift));
     }
 
 }

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp
@@ -61,6 +61,7 @@ namespace QuantLib {
                     const std::vector<std::vector<Handle<Quote> > >& vols,
                     const DayCounter& dayCounter,
                     const bool flatExtrapolation = false,
+                    const VolatilityType type = ShiftedLognormal,
                     const std::vector<std::vector<Real> >& shifts
                     = std::vector<std::vector<Real> >());
         //! fixed reference date, floating market data
@@ -73,6 +74,7 @@ namespace QuantLib {
                     const std::vector<std::vector<Handle<Quote> > >& vols,
                     const DayCounter& dayCounter,
                     const bool flatExtrapolation = false,
+                    const VolatilityType type = ShiftedLognormal,
                     const std::vector<std::vector<Real> >& shifts
                     = std::vector<std::vector<Real> >());
         //! floating reference date, fixed market data
@@ -84,6 +86,7 @@ namespace QuantLib {
                     const Matrix& volatilities,
                     const DayCounter& dayCounter,
                     const bool flatExtrapolation = false,
+                    const VolatilityType type = ShiftedLognormal,
                     const Matrix& shifts = Matrix());
         //! fixed reference date, fixed market data
         SwaptionVolatilityMatrix(
@@ -95,6 +98,7 @@ namespace QuantLib {
                     const Matrix& volatilities,
                     const DayCounter& dayCounter,
                     const bool flatExtrapolation = false,
+                    const VolatilityType type = ShiftedLognormal,
                     const Matrix& shifts = Matrix());
         // fixed reference date and fixed market data, option dates
         SwaptionVolatilityMatrix(const Date& referenceDate,
@@ -103,6 +107,7 @@ namespace QuantLib {
                                  const Matrix& volatilities,
                                  const DayCounter& dayCounter,
                                  const bool flatExtrapolation = false,
+                                 const VolatilityType type = ShiftedLognormal,
                                  const Matrix& shifts = Matrix());
         //! \name LazyObject interface
         //@{
@@ -136,6 +141,14 @@ namespace QuantLib {
                                   interpolation_.locateX(swapLength));
         }
         //@}
+        Real shift(Time optionTime, Time swapLength) const {
+            calculate();
+            Real tmp = interpolationShifts_(swapLength, optionTime, true);
+            return tmp;
+        }
+        VolatilityType volatilityType() const {
+            return volatilityType_;
+        }
       protected:
         // defining the following method would break CMS test suite
         // to be further investigated
@@ -146,11 +159,6 @@ namespace QuantLib {
         Volatility volatilityImpl(Time optionTime,
                                   Time swapLength,
                                   Rate strike) const;
-        Real shift(Time optionTime, Time swapLength) const {
-            calculate();
-            Real tmp = interpolationShifts_(swapLength, optionTime, true);
-            return tmp;
-        }
       private:
         void checkInputs(Size volRows,
                          Size volsColumns,
@@ -161,6 +169,7 @@ namespace QuantLib {
         std::vector<std::vector<Real> > shiftValues_;
         mutable Matrix volatilities_, shifts_;
         Interpolation2D interpolation_, interpolationShifts_;
+        VolatilityType volatilityType_;
     };
 
     // inline definitions

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp
@@ -141,14 +141,7 @@ namespace QuantLib {
                                   interpolation_.locateX(swapLength));
         }
         //@}
-        Real shift(Time optionTime, Time swapLength) const {
-            calculate();
-            Real tmp = interpolationShifts_(swapLength, optionTime, true);
-            return tmp;
-        }
-        VolatilityType volatilityType() const {
-            return volatilityType_;
-        }
+        VolatilityType volatilityType() const;
       protected:
         // defining the following method would break CMS test suite
         // to be further investigated
@@ -159,6 +152,7 @@ namespace QuantLib {
         Volatility volatilityImpl(Time optionTime,
                                   Time swapLength,
                                   Rate strike) const;
+        Real shiftImpl(Time optionTime, Time swapLength) const;
       private:
         void checkInputs(Size volRows,
                          Size volsColumns,
@@ -197,6 +191,16 @@ namespace QuantLib {
         return interpolation_(swapLength, optionTime, true);
     }
 
-}
+    inline VolatilityType SwaptionVolatilityMatrix::volatilityType() const {
+        return volatilityType_;
+    }
+
+    inline Real SwaptionVolatilityMatrix::shiftImpl(Time optionTime,
+                                                    Time swapLength) const {
+        calculate();
+        Real tmp = interpolationShifts_(swapLength, optionTime, true);
+        return tmp;
+    }
+} // namespace QuantLib
 
 #endif

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolstructure.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolstructure.hpp
@@ -4,6 +4,7 @@
  Copyright (C) 2002, 2003 RiskMap srl
  Copyright (C) 2003, 2004, 2005, 2006 StatPro Italia srl
  Copyright (C) 2006, 2008 Ferdinando Ametrano
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -27,6 +28,7 @@
 #define quantlib_swaption_volatility_structure_hpp
 
 #include <ql/termstructures/voltermstructure.hpp>
+#include <ql/termstructures/volatility/volatilitytype.hpp>
 
 namespace QuantLib {
 
@@ -160,7 +162,14 @@ namespace QuantLib {
         //@{
         //! shift size for displaced lognormal volatility
         virtual Real shift(Time optionTime, Time swapLength) const {
+            QL_REQUIRE(
+                volatilityType() == ShiftedLognormal,
+                "shift parameter only makes sense for lognormal volatilities");
             return 0.0;
+        }
+        //! volatility type
+        virtual VolatilityType volatilityType() const {
+            return ShiftedLognormal;
         }
         //@}
         //! implements the conversion between swap tenor and swap (time) length

--- a/QuantLib/ql/termstructures/volatility/swaption/swaptionvolstructure.hpp
+++ b/QuantLib/ql/termstructures/volatility/swaption/swaptionvolstructure.hpp
@@ -127,6 +127,31 @@ namespace QuantLib {
                            Rate strike,
                            bool extrapolate = false) const;
 
+        //! returns the shift for a given option tenor and swap tenor
+        Real shift(const Period& optionTenor,
+                   const Period& swapTenor,
+                   bool extrapolate = false) const;
+        //! returns the shift for a given option date and swap tenor
+        Real shift(const Date& optionDate,
+                   const Period& swapTenor,
+                   bool extrapolate = false) const;
+        //! returns the shift for a given option time and swap tenor
+        Real shift(Time optionTime,
+                   const Period& swapTenor,
+                   bool extrapolate = false) const;
+        //! returns the shift for a given option tenor and swap length
+        Real shift(const Period& optionTenor,
+                   Time swapLength,
+                   bool extrapolate = false) const;
+        //! returns the shift for a given option date and swap length
+        Real shift(const Date& optionDate,
+                   Time swapLength,
+                   bool extrapolate = false) const;
+        //! returns the shift for a given option time and swap length
+        Real shift(Time optionTime,
+                   Time swapLength,
+                   bool extrapolate = false) const;
+
         //! returns the smile for a given option tenor and swap tenor
         boost::shared_ptr<SmileSection> smileSection(const Period& optionTenor,
                                                      const Period& swapTenor,
@@ -160,13 +185,6 @@ namespace QuantLib {
         Time maxSwapLength() const;
         //@}
         //@{
-        //! shift size for displaced lognormal volatility
-        virtual Real shift(Time optionTime, Time swapLength) const {
-            QL_REQUIRE(
-                volatilityType() == ShiftedLognormal,
-                "shift parameter only makes sense for lognormal volatilities");
-            return 0.0;
-        }
         //! volatility type
         virtual VolatilityType volatilityType() const {
             return ShiftedLognormal;
@@ -190,6 +208,9 @@ namespace QuantLib {
         virtual Volatility volatilityImpl(Time optionTime,
                                           Time swapLength,
                                           Rate strike) const = 0;
+        virtual Real shiftImpl(const Date &optionDate,
+                               const Period &swapTenor) const;
+        virtual Real shiftImpl(Time optionTime, Time swapLength) const;
         void checkSwapTenor(const Period& swapTenor,
                             bool extrapolate) const;
         void checkSwapTenor(Time swapLength,
@@ -234,6 +255,22 @@ namespace QuantLib {
                                                     bool extrapolate) const {
         Date optionDate = optionDateFromTenor(optionTenor);
         return blackVariance(optionDate, swapLength, strike, extrapolate);
+    }
+
+    inline
+    Real SwaptionVolatilityStructure::shift(const Period& optionTenor,
+                                            const Period& swapTenor,
+                                            bool extrapolate) const {
+        Date optionDate = optionDateFromTenor(optionTenor);
+        return shift(optionDate, swapTenor, extrapolate);
+    }
+
+    inline
+    Real SwaptionVolatilityStructure::shift(const Period& optionTenor,
+                                            Time swapLength,
+                                            bool extrapolate) const {
+        Date optionDate = optionDateFromTenor(optionTenor);
+        return shift(optionDate, swapLength, extrapolate);
     }
 
     inline boost::shared_ptr<SmileSection>
@@ -330,6 +367,44 @@ namespace QuantLib {
         return volatilityImpl(optionTime, swapLength, strike);
     }
 
+    inline Real
+    SwaptionVolatilityStructure::shift(const Date& optionDate,
+                                            const Period& swapTenor,
+                                            bool extrapolate) const {
+        checkSwapTenor(swapTenor, extrapolate);
+        checkRange(optionDate, extrapolate);
+        return shiftImpl(optionDate, swapTenor);
+    }
+
+    inline Real
+    SwaptionVolatilityStructure::shift(const Date& optionDate,
+                                            Time swapLength,
+                                            bool extrapolate) const {
+        checkSwapTenor(swapLength, extrapolate);
+        checkRange(optionDate, extrapolate);
+        Time optionTime = timeFromReference(optionDate);
+        return shiftImpl(optionTime, swapLength);
+    }
+
+    inline Volatility
+    SwaptionVolatilityStructure::shift(Time optionTime,
+                                            const Period& swapTenor,
+                                            bool extrapolate) const {
+        checkSwapTenor(swapTenor, extrapolate);
+        checkRange(optionTime, extrapolate);
+        Time length = swapLength(swapTenor);
+        return shiftImpl(optionTime, length);
+    }
+
+    inline Volatility
+    SwaptionVolatilityStructure::shift(Time optionTime,
+                                            Time swapLength,
+                                            bool extrapolate) const {
+        checkSwapTenor(swapLength, extrapolate);
+        checkRange(optionTime, extrapolate);
+        return shiftImpl(optionTime, swapLength);
+    }
+
     inline boost::shared_ptr<SmileSection>
     SwaptionVolatilityStructure::smileSection(const Date& optionDate,
                                               const Period& swapTenor,
@@ -364,6 +439,19 @@ namespace QuantLib {
         return volatilityImpl(timeFromReference(optionDate),
                               swapLength(swapTenor),
                               strike);
+    }
+
+    inline Real
+    SwaptionVolatilityStructure::shiftImpl(const Date &optionDate,
+                                           const Period &swapTenor) const {
+        return shiftImpl(timeFromReference(optionDate), swapLength(swapTenor));
+    }
+
+    inline Real SwaptionVolatilityStructure::shiftImpl(Time, Time) const {
+        QL_REQUIRE(
+            volatilityType() == ShiftedLognormal,
+            "shift parameter only makes sense for lognormal volatilities");
+        return 0.0;
     }
 
     inline Time SwaptionVolatilityStructure::maxSwapLength() const {


### PR DESCRIPTION
there is a breaking change since I changed the order of parameters volatilityType and shift at some places - however since the shift parameter was only added very recently, this can maybe be tolerated ? The other way round the constructor calls wouldn't be natural since one would have to provide a shift even for normal-style volatility structures