### PR TITLE
freeze evaluation date for test suite

### DIFF
--- a/QuantLib/ql/settings.hpp
+++ b/QuantLib/ql/settings.hpp
@@ -174,6 +174,18 @@ namespace QuantLib {
         return enforcesTodaysHistoricFixings_;
     }
 
+    inline std::ostream &operator<<(std::ostream &out, const Settings &s) {
+        return out << "evaluation date is " << s.evaluationDate() << ",\n"
+                   << (s.includeReferenceDateEvents()
+                           ? "reference date events are included,\n"
+                           : "reference date events are excluded,\n")
+                   << (s.includeTodaysCashFlows()
+                           ? "today's cashflows are included,\n"
+                           : "today's cashflows are excluded,\n")
+                   << (s.enforcesTodaysHistoricFixings()
+                           ? "today's historic fixings are enforced"
+                           : "today's historic fixings are not enforced");
+    }
 }
 
 #endif

--- a/QuantLib/test-suite/asianoptions.cpp
+++ b/QuantLib/test-suite/asianoptions.cpp
@@ -92,7 +92,7 @@ void AsianOptionTest::testAnalyticContinuousGeometricAveragePrice() {
     // data from "Option Pricing Formulas", Haug, pag.96-97
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(80.0));
     boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(-0.03));
@@ -189,7 +189,7 @@ void AsianOptionTest::testAnalyticContinuousGeometricAveragePriceGreeks() {
     Volatility vols[] = { 0.11, 0.50, 1.20 };
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
     Settings::instance().evaluationDate() = today;
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
@@ -331,7 +331,7 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAveragePrice() {
     // Clewlow, Strickland, p.118-123
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
     boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
@@ -390,7 +390,7 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAverageStrike() {
               "Testing analytic discrete geometric average-strike Asians...");
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
     boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
@@ -453,7 +453,7 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePrice() {
     // Clewlow, Strickland, p.118-123
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
     boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
@@ -607,7 +607,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePrice() {
    };
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
     boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
@@ -762,7 +762,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAverageStrike() {
     };
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
     boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
@@ -849,7 +849,7 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceGreeks() {
     Volatility vols[] = { 0.11, 0.50, 1.20 };
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
     Settings::instance().evaluationDate() = today;
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
@@ -995,7 +995,7 @@ void AsianOptionTest::testPastFixings() {
     BOOST_TEST_MESSAGE("Testing use of past fixings in Asian options...");
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
     boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
@@ -1174,7 +1174,7 @@ void AsianOptionTest::testLevyEngine() {
     };
 
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     for (Size l=0; l<LENGTH(cases); l++) {
 
@@ -1261,9 +1261,9 @@ void AsianOptionTest::testVecerEngine() {
         { 2.0, 0.05,   0.5,  2.0, 2, 0.350095, 2.0e-4 }
     };
 
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
     DayCounter dayCounter = Actual360();
-    
+
     Option::Type type = Option::Call;
     Handle<YieldTermStructure> q(flatRate(today, 0.0, dayCounter));
 
@@ -1280,7 +1280,7 @@ void AsianOptionTest::testVecerEngine() {
                                                     dayCounter));
         boost::shared_ptr<BlackScholesMertonProcess> process =
             boost::make_shared<BlackScholesMertonProcess>(u, q, r, sigma);
-        
+
         Date maturity = today + cases[i].length*360;
         boost::shared_ptr<Exercise> exercise =
             boost::make_shared<EuropeanExercise>(maturity);
@@ -1338,4 +1338,3 @@ test_suite* AsianOptionTest::experimental() {
     suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testVecerEngine));
     return suite;
 }
-

--- a/QuantLib/test-suite/chooseroption.cpp
+++ b/QuantLib/test-suite/chooseroption.cpp
@@ -59,7 +59,7 @@ void ChooserOptionTest::testAnalyticSimpleChooserEngine(){
        pages 39-40
     */
     DayCounter dc = Actual360();
-    Date today = Date::todaysDate();
+    Date today = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot = boost::make_shared<SimpleQuote>(50.0);
     boost::shared_ptr<SimpleQuote> qRate = boost::make_shared<SimpleQuote>(0.0);

--- a/QuantLib/test-suite/compoundoption.cpp
+++ b/QuantLib/test-suite/compoundoption.cpp
@@ -111,7 +111,7 @@ void CompoundOptionTest::testPutCallParity(){
     Calendar calendar = TARGET();
 
     DayCounter dc = Actual360();
-    Date todaysDate = Date::todaysDate();
+    Date todaysDate = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
     boost::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
@@ -246,7 +246,7 @@ void CompoundOptionTest::testValues(){
     Calendar calendar = TARGET();
 
     DayCounter dc = Actual360();
-    Date todaysDate = Date::todaysDate();
+    Date todaysDate = Settings::instance().evaluationDate();
 
     boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
     boost::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));

--- a/QuantLib/test-suite/digitalcoupon.cpp
+++ b/QuantLib/test-suite/digitalcoupon.cpp
@@ -58,7 +58,7 @@ namespace {
             nominal = 1000000.0;
             index = boost::shared_ptr<IborIndex>(new Euribor6M(termStructure));
             calendar = index->fixingCalendar();
-            today = calendar.adjust(Date::todaysDate());
+            today = calendar.adjust(Settings::instance().evaluationDate());
             Settings::instance().evaluationDate() = today;
             settlement = calendar.advance(today,fixingDays,Days);
             termStructure.linkTo(flatRate(settlement,0.05,Actual365Fixed()));

--- a/QuantLib/test-suite/forwardoption.cpp
+++ b/QuantLib/test-suite/forwardoption.cpp
@@ -398,7 +398,9 @@ void ForwardOptionTest::testGreeksInitialization() {
    BOOST_TEST_MESSAGE("Testing forward option greeks initialization...");
 
    DayCounter dc = Actual360();
-   Date today = Settings::instance().evaluationDate();
+   SavedSettings backup;
+   Date today = Date::todaysDate();
+   Settings::instance().evaluationDate() = today;
 
    boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
    boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));

--- a/QuantLib/test-suite/forwardoption.cpp
+++ b/QuantLib/test-suite/forwardoption.cpp
@@ -398,8 +398,7 @@ void ForwardOptionTest::testGreeksInitialization() {
    BOOST_TEST_MESSAGE("Testing forward option greeks initialization...");
 
    DayCounter dc = Actual360();
-   Date today = Date::todaysDate();
-   Settings::instance().evaluationDate() = today;
+   Date today = Settings::instance().evaluationDate();
 
    boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
    boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));

--- a/QuantLib/test-suite/quantlibtestsuite.cpp
+++ b/QuantLib/test-suite/quantlibtestsuite.cpp
@@ -201,7 +201,7 @@ namespace {
     }
 
     void configure() {
-        /* if needed, either or both the lines below can be
+        /* if needed, a subset of the lines below can be
            uncommented and/or changed to run the test suite with a
            different configuration. In the future, we'll need a
            mechanism that doesn't force us to recompile (possibly a
@@ -210,6 +210,17 @@ namespace {
 
         //QuantLib::Settings::instance().includeReferenceDateCashFlows() = true;
         //QuantLib::Settings::instance().includeTodaysCashFlows() = boost::none;
+
+        /* does not throw evaluation date dependent errors */
+        QuantLib::Settings::instance().evaluationDate() =
+            QuantLib::Date(16, QuantLib::Sep, 2015);
+
+        /* throws 3 evaluation date dependent errors
+           (in MarketModelSmmCapletCalibrationTest,
+           MarketModelSmmCapletAlphaCalibrationTest and
+           MarketModelSmmAlphaCalibrationTest) */
+        // QuantLib::Settings::instance().evaluationDate() =
+        //     QuantLib::Date(29, QuantLib::Aug, 2015);
     }
 
 }
@@ -224,6 +235,8 @@ namespace QuantLib {
 
 test_suite* init_unit_test_suite(int, char* []) {
 
+    std::ostringstream settingsDesc;
+    settingsDesc << QuantLib::Settings::instance();
     std::string header =
         " Testing "
             #ifdef BOOST_MSVC
@@ -249,8 +262,9 @@ test_suite* init_unit_test_suite(int, char* []) {
             #else
             " undefined"
             #endif
+        "\n" + settingsDesc.str()
          ;
-    std::string rule = std::string(35, '=');
+    std::string rule = std::string(41, '=');
 
     BOOST_TEST_MESSAGE(rule);
     BOOST_TEST_MESSAGE(header);
@@ -258,7 +272,8 @@ test_suite* init_unit_test_suite(int, char* []) {
     test_suite* test = BOOST_TEST_SUITE("QuantLib test suite");
 
     test->add(QUANTLIB_TEST_CASE(startTimer));
-    test->add(QUANTLIB_TEST_CASE(configure));
+    // ensure execution even when a test case filter is specified
+    configure();
 
     test->add(AmericanOptionTest::suite());
     test->add(ArrayTest::suite());

--- a/QuantLib/test-suite/quantlibtestsuite.cpp
+++ b/QuantLib/test-suite/quantlibtestsuite.cpp
@@ -235,6 +235,8 @@ namespace QuantLib {
 
 test_suite* init_unit_test_suite(int, char* []) {
 
+    configure();
+
     std::ostringstream settingsDesc;
     settingsDesc << QuantLib::Settings::instance();
     std::string header =
@@ -272,8 +274,6 @@ test_suite* init_unit_test_suite(int, char* []) {
     test_suite* test = BOOST_TEST_SUITE("QuantLib test suite");
 
     test->add(QUANTLIB_TEST_CASE(startTimer));
-    // ensure execution even when a test case filter is specified
-    configure();
 
     test->add(AmericanOptionTest::suite());
     test->add(ArrayTest::suite());


### PR DESCRIPTION
This freezes the evaluation date for the test suite execution to a date where none of the known evaluation date - dependent errors occur. Test cases may still deliberately choose to depend on the system date (thus being randomized in a certain sense; some cases do so by using `Date::todaysDate()`), but otherwise the suite will run in a deterministic way w.r.t. the evaluation date. Furthermore the configuration method (which also contains the fixed evaluation date now) was not executed if a test case filter was applied by the `--run_test` command line option. This is fixed by explicity calling the method during the initialization phase instead of wrapping it into an own test case. Finally the settings configuration is output together with the configure switches.