### PR TITLE
Recompute switchstrike for caplets

### DIFF
--- a/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -24,6 +24,7 @@
 #include <ql/termstructures/volatility/optionlet/optionletstripper1.hpp>
 #include <ql/instruments/makecapfloor.hpp>
 #include <ql/pricingengines/capfloor/blackcapfloorengine.hpp>
+#include <ql/pricingengine.hpp>
 #include <ql/pricingengines/capfloor/bacheliercapfloorengine.hpp>
 #include <ql/pricingengines/blackformula.hpp>
 #include <ql/indexes/iborindex.hpp>
@@ -60,7 +61,7 @@ namespace QuantLib {
         optionletStDevs_ = Matrix(nOptionletTenors_, nStrikes_, firstGuess);
 
         capFloors_ = CapFloorMatrix(nOptionletTenors_);
-        capFloorEngines_ = std::vector<std::vector<boost::shared_ptr<CapFloor::engine> > >(nOptionletTenors_);
+        capFloorEngines_ = std::vector<std::vector<boost::shared_ptr<PricingEngine> > >(nOptionletTenors_);
     }
 
     void OptionletStripper1::performCalculations() const {

--- a/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -87,7 +87,7 @@ namespace QuantLib {
             atmOptionletRate_[i] = lFRC->indexFixing();
         }
 
-        if (floatingSwitchStrike_ && capFlooMatrixNotInitialized_) {
+        if (floatingSwitchStrike_) {
             Rate averageAtmOptionletRate = 0.0;
             for (Size i=0; i<nOptionletTenors_; ++i) {
                 averageAtmOptionletRate += atmOptionletRate_[i];

--- a/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -55,10 +55,12 @@ namespace QuantLib {
         capFloorPrices_ = Matrix(nOptionletTenors_, nStrikes_);
         optionletPrices_ = Matrix(nOptionletTenors_, nStrikes_);
         capFloorVols_ = Matrix(nOptionletTenors_, nStrikes_);
+
         Real firstGuess = 0.14; // guess is only used for shifted lognormal vols
         optionletStDevs_ = Matrix(nOptionletTenors_, nStrikes_, firstGuess);
 
         capFloors_ = CapFloorMatrix(nOptionletTenors_);
+        capFloorEngines_ = std::vector<std::vector<boost::shared_ptr<CapFloor::engine> > >(nOptionletTenors_);
     }
 
     void OptionletStripper1::performCalculations() const {
@@ -103,34 +105,25 @@ namespace QuantLib {
         const std::vector<Rate>& strikes = termVolSurface_->strikes();
         // initialize CapFloorMatrix
         if (capFlooMatrixNotInitialized_) {
-            for (Size i=0; i<nOptionletTenors_; ++i)
+            for (Size i = 0; i < nOptionletTenors_; ++i) {
                 capFloors_[i].resize(nStrikes_);
+                capFloorEngines_[i].resize(nStrikes_);
+            }
             // construction might go here
             for (Size j=0; j<nStrikes_; ++j) {
-                // using out-of-the-money options
-                CapFloor::Type capFloorType = strikes[j] < switchStrike_ ?
-                                       CapFloor::Floor : CapFloor::Cap;
                 for (Size i=0; i<nOptionletTenors_; ++i) {
                     volQuotes_[i][j] = shared_ptr<SimpleQuote>(new
                                                                 SimpleQuote());
                     if (volatilityType_ == ShiftedLognormal) {
-                      shared_ptr<BlackCapFloorEngine> engine(
+                        capFloorEngines_[i][j]=boost::shared_ptr<BlackCapFloorEngine>(
                           new BlackCapFloorEngine(
                               discountCurve, Handle<Quote>(volQuotes_[i][j]),
                               dc, displacement_));
-                      capFloors_[i][j] =
-                          MakeCapFloor(capFloorType, capFloorLengths_[i],
-                                       iborIndex_, strikes[j],
-                                       0 * Days).withPricingEngine(engine);
                     } else if (volatilityType_ == Normal) {
-                      shared_ptr<BachelierCapFloorEngine> engine(
+                        capFloorEngines_[i][j]=boost::shared_ptr<BachelierCapFloorEngine>(
                           new BachelierCapFloorEngine(
                               discountCurve, Handle<Quote>(volQuotes_[i][j]),
                               dc));
-                      capFloors_[i][j] =
-                          MakeCapFloor(capFloorType, capFloorLengths_[i],
-                                       iborIndex_, strikes[j],
-                                       0 * Days).withPricingEngine(engine);
                     } else {
                       QL_FAIL("unknown volatility type: " << volatilityType_);
                     }
@@ -140,9 +133,11 @@ namespace QuantLib {
         }
 
         for (Size j=0; j<nStrikes_; ++j) {
-
-            Option::Type optionletType = strikes[j] < switchStrike_ ?
-                                   Option::Put : Option::Call;
+            // using out-of-the-money options
+            CapFloor::Type capFloorType =
+                strikes[j] < switchStrike_ ? CapFloor::Floor : CapFloor::Cap;
+            Option::Type optionletType =
+                strikes[j] < switchStrike_ ? Option::Put : Option::Call;
 
             Real previousCapFloorPrice = 0.0;
             for (Size i=0; i<nOptionletTenors_; ++i) {
@@ -150,7 +145,10 @@ namespace QuantLib {
                 capFloorVols_[i][j] = termVolSurface_->volatility(
                     capFloorLengths_[i], strikes[j], true);
                 volQuotes_[i][j]->setValue(capFloorVols_[i][j]);
-
+                capFloors_[i][j] =
+                    MakeCapFloor(capFloorType, capFloorLengths_[i],
+                                 iborIndex_, strikes[j], -0 * Days)
+                        .withPricingEngine(capFloorEngines_[i][j]);
                 capFloorPrices_[i][j] = capFloors_[i][j]->NPV();
                 optionletPrices_[i][j] = capFloorPrices_[i][j] -
                                                         previousCapFloorPrice;

--- a/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
+++ b/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
@@ -34,6 +34,8 @@
 namespace QuantLib {
 
     class SimpleQuote;
+    class CapFloor;
+    class PricingEngine;
 
     typedef std::vector<std::vector<boost::shared_ptr<CapFloor> > > CapFloorMatrix;
 
@@ -69,7 +71,7 @@ namespace QuantLib {
 
         mutable CapFloorMatrix capFloors_;
         mutable std::vector<std::vector<boost::shared_ptr<SimpleQuote> > > volQuotes_;
-        mutable std::vector<std::vector<boost::shared_ptr<CapFloor::engine> > > capFloorEngines_;
+        mutable std::vector<std::vector<boost::shared_ptr<PricingEngine> > > capFloorEngines_;
         bool floatingSwitchStrike_;
         mutable bool capFlooMatrixNotInitialized_;
         mutable Rate switchStrike_;

--- a/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
+++ b/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
@@ -29,7 +29,6 @@
 #define quantlib_optionletstripper1_hpp
 
 #include <ql/termstructures/volatility/optionlet/optionletstripper.hpp>
-#include <ql/instruments/capfloor.hpp>
 
 namespace QuantLib {
 

--- a/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
+++ b/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
@@ -5,6 +5,7 @@
  Copyright (C) 2007 François du Vignaud
  Copyright (C) 2007 Katiuscia Manzoni
  Copyright (C) 2007 Giorgio Facchinetti
+ Copyright (C) 2015 Michael von den Driesch
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -28,10 +29,10 @@
 #define quantlib_optionletstripper1_hpp
 
 #include <ql/termstructures/volatility/optionlet/optionletstripper.hpp>
+#include <ql/instruments/capfloor.hpp>
 
 namespace QuantLib {
 
-    class CapFloor;
     class SimpleQuote;
 
     typedef std::vector<std::vector<boost::shared_ptr<CapFloor> > > CapFloorMatrix;
@@ -68,6 +69,7 @@ namespace QuantLib {
 
         mutable CapFloorMatrix capFloors_;
         mutable std::vector<std::vector<boost::shared_ptr<SimpleQuote> > > volQuotes_;
+        mutable std::vector<std::vector<boost::shared_ptr<CapFloor::engine> > > capFloorEngines_;
         bool floatingSwitchStrike_;
         mutable bool capFlooMatrixNotInitialized_;
         mutable Rate switchStrike_;


### PR DESCRIPTION
Fixing issue with switch strike computation in caplet stripping. Previous implementation ignored recalculation of the switchstrike in case of a *moving* forward curve.