### PR TITLE
add piecewise integral and function

### DIFF
--- a/QuantLib/ql/experimental/math/Makefile.am
+++ b/QuantLib/ql/experimental/math/Makefile.am
@@ -14,6 +14,8 @@ this_include_HEADERS = \
     multidimintegrator.hpp \
     multidimquadrature.hpp \
     numericaldifferentiation.hpp \
+	piecewisefunction.hpp \
+	piecewiseintegral.hpp \
     polarstudenttrng.hpp \
     tcopulapolicy.hpp \
     zigguratrng.hpp
@@ -25,6 +27,7 @@ libMath_la_SOURCES = \
     multidimintegrator.cpp \
     multidimquadrature.cpp \
     numericaldifferentiation.cpp \
+	piecewiseintegral.cpp \
     tcopulapolicy.cpp \
     zigguratrng.cpp
 

--- a/QuantLib/ql/experimental/math/Makefile.am
+++ b/QuantLib/ql/experimental/math/Makefile.am
@@ -14,8 +14,8 @@ this_include_HEADERS = \
     multidimintegrator.hpp \
     multidimquadrature.hpp \
     numericaldifferentiation.hpp \
-	piecewisefunction.hpp \
-	piecewiseintegral.hpp \
+    piecewisefunction.hpp \
+    piecewiseintegral.hpp \
     polarstudenttrng.hpp \
     tcopulapolicy.hpp \
     zigguratrng.hpp
@@ -27,7 +27,7 @@ libMath_la_SOURCES = \
     multidimintegrator.cpp \
     multidimquadrature.cpp \
     numericaldifferentiation.cpp \
-	piecewiseintegral.cpp \
+    piecewiseintegral.cpp \
     tcopulapolicy.cpp \
     zigguratrng.cpp
 

--- a/QuantLib/ql/experimental/math/all.hpp
+++ b/QuantLib/ql/experimental/math/all.hpp
@@ -11,6 +11,8 @@
 #include <ql/experimental/math/multidimintegrator.hpp>
 #include <ql/experimental/math/multidimquadrature.hpp>
 #include <ql/experimental/math/numericaldifferentiation.hpp>
+#include <ql/experimental/math/piecewisefunction.hpp>
+#include <ql/experimental/math/piecewiseintegral.hpp>
 #include <ql/experimental/math/polarstudenttrng.hpp>
 #include <ql/experimental/math/tcopulapolicy.hpp>
 #include <ql/experimental/math/zigguratrng.hpp>

--- a/QuantLib/ql/experimental/math/piecewisefunction.hpp
+++ b/QuantLib/ql/experimental/math/piecewisefunction.hpp
@@ -1,0 +1,46 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2015 Peter Caspers
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file piecewisefunction.hpp
+    \brief utility macro for piecewise functions
+*/
+
+#ifndef quantlib_piecewise_function_hpp
+#define quantlib_piecewise_function_hpp
+
+#include <algorithm>
+
+/*! This defines a piecewise constant function which is RCLL and takes
+    the values Y[0], Y[1], ... Y[n] on the intervals
+    (-\infty, X[0]), [ X[1], X[2] ), ... , [ X[n-1], \infty)
+    Normally Y.size() should be X.size() + 1. If more values for Y are
+    given, they are ignored. If less values are given the last given
+    value is kept the same for the remaining intervals.
+    If X.size() is 0 a constant function taking the value Y[0] is
+    evaluated.
+
+    \warning If Y.size() is 0, an invalid access occurs. This
+             condition is not checked for performance reasons.
+*/
+
+#define QL_PIECEWISE_FUNCTION(X, Y, x)                                         \
+    Y[std::min<std::size_t>(                                                   \
+        std::upper_bound(X.begin(), X.end(), x) - X.begin(), Y.size() - 1)]
+
+#endif

--- a/QuantLib/ql/experimental/math/piecewiseintegral.cpp
+++ b/QuantLib/ql/experimental/math/piecewiseintegral.cpp
@@ -1,0 +1,39 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2015 Peter Caspers
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/experimental/math/piecewiseintegral.hpp>
+
+namespace QuantLib {
+
+PiecewiseIntegral::PiecewiseIntegral(
+    const boost::shared_ptr<Integrator> &integrator,
+    const std::vector<Real> &criticalPoints, const bool avoidCriticalPoints)
+    : Integrator(1.0, 1), integrator_(integrator),
+      criticalPoints_(criticalPoints),
+      eps_(avoidCriticalPoints ? (1.0 + QL_EPSILON) : 1.0) {
+
+    std::sort(criticalPoints_.begin(), criticalPoints_.end());
+    std::vector<Real>::const_iterator end =
+        std::unique(criticalPoints_.begin(), criticalPoints_.end(),
+                    std::ptr_fun(close_enough));
+    criticalPoints_.resize(end - criticalPoints_.begin());
+
+}
+
+} // namespace QuantLib

--- a/QuantLib/ql/experimental/math/piecewiseintegral.hpp
+++ b/QuantLib/ql/experimental/math/piecewiseintegral.hpp
@@ -1,0 +1,107 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2015 Peter Caspers
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file piecewiseintegral.hpp
+    \brief Integral of a piecewise well behaved function using
+           a custom integrator for the pieces. It can be forced
+           that the function is integrated only over intervals
+           strictly not containing the critical points
+*/
+
+#ifndef quantlib_piecewise_integral_hpp
+#define quantlib_piecewise_integral_hpp
+
+#include <ql/math/integrals/integral.hpp>
+#include <ql/math/comparison.hpp>
+#include <boost/shared_ptr.hpp>
+
+#include <vector>
+
+namespace QuantLib {
+
+class PiecewiseIntegral : public Integrator {
+  public:
+    PiecewiseIntegral(const boost::shared_ptr<Integrator> &integrator,
+                      const std::vector<Real> &criticalPoints,
+                      const bool avoidCriticalPoints = true);
+
+  protected:
+    Real integrate(const boost::function<Real(Real)> &f, Real a, Real b) const;
+
+  private:
+    Real integrate_h(const boost::function<Real(Real)> &f, Real a,
+                     Real b) const;
+    const boost::shared_ptr<Integrator> integrator_;
+    std::vector<Real> criticalPoints_;
+    const Real eps_;
+};
+
+// inline
+
+inline Real PiecewiseIntegral::integrate_h(const boost::function<Real(Real)> &f,
+                                           Real a, Real b) const {
+
+    if (!close_enough(a, b))
+        return integrator_->operator()(f, a, b);
+    else
+        return 0.0;
+}
+
+inline Real PiecewiseIntegral::integrate(const boost::function<Real(Real)> &f,
+                                         Real a, Real b) const {
+
+    std::vector<Real>::const_iterator a0 =
+        std::lower_bound(criticalPoints_.begin(), criticalPoints_.end(), a);
+
+    std::vector<Real>::const_iterator b0 =
+        std::lower_bound(criticalPoints_.begin(), criticalPoints_.end(), b);
+
+    if (a0 == criticalPoints_.end()) {
+        Real tmp = 1.0;
+        if (!criticalPoints_.empty()) {
+            if (close_enough(a, criticalPoints_.back())) {
+                tmp = eps_;
+            }
+        }
+        return integrate_h(f, a * tmp, b);
+    }
+
+    Real res = 0.0;
+
+    if (!close_enough(a, *a0)) {
+        res += integrate_h(f, a, std::min(*a0 / eps_, b));
+    }
+
+    if (b0 == criticalPoints_.end()) {
+        b0--;
+        if (!close_enough(*b0, b)) {
+            res += integrate_h(f, (*b0) * eps_, b);
+        }
+    }
+
+    for (std::vector<Real>::const_iterator x = a0; x < b0; ++x) {
+        res += integrate_h(f, (*x) * eps_, std::min(*(x + 1) / eps_, b));
+    }
+
+    return res;
+}
+
+} // namespace QuantLib
+
+#endif

--- a/QuantLib/test-suite/integrals.hpp
+++ b/QuantLib/test-suite/integrals.hpp
@@ -37,6 +37,7 @@ class IntegralTest {
     static void testTwoDimensionalIntegration();
     static void testFolinIntegration();
     static void testDiscreteIntegrals();
+    static void testPiecewiseIntegral();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
This adds an integrator suitable for functions that are piecewise well behaved. For example, piecewise constant functions can easily be integrated exactly (using a `SegmentIntegral` with 1 point as the base integrator). Other functions that are piecewise smooth can be integrated more efficiently. In addition it can be avoided that the function is evaluated at the critical points.

Secondly, a small macro to support the implementation of piecewise constant functions based on x / y coordinates given in STL containers (like `vector`, `list` and the like) is added.

This will be used in some new models I hope to contribute soon, but seems interesting enough on a standalone basis as well.