### PR TITLE
Improved  Saudi Arabia calendar (no rename)

### DIFF
--- a/QuantLib/ql/time/calendars/saudiarabia.cpp
+++ b/QuantLib/ql/time/calendars/saudiarabia.cpp
@@ -20,18 +20,19 @@
 
 #include <ql/time/calendars/saudiarabia.hpp>
 #include <ql/errors.hpp>
+#include <boost/assign/list_of.hpp> // for 'list_of()'
 
 namespace QuantLib {
 
     SaudiArabia::SaudiArabia(Market market) {
         // all calendar instances share the same implementation instance
         static boost::shared_ptr<Calendar::Impl> tadawulImpl(
-                                                new SaudiArabia::TadawulImpl);
+                                                             new SaudiArabia::TadawulImpl);
         switch (market) {
-          case Tadawul:
+        case Tadawul:
             impl_ = tadawulImpl;
             break;
-          default:
+        default:
             QL_FAIL("unknown market");
         }
     }
@@ -46,20 +47,111 @@ namespace QuantLib {
         Month m = date.month();
         Year y = date.year();
 
-        if (isWeekend(w)
+        // Eid al Adha dates taken from:
+        // https://en.wikipedia.org/wiki/Eid_al-Adha#Eid_al-Adha_in_the_Gregorian_calendar
+        static std::vector<Date> EidAlAdha = boost::assign::list_of(Date(7, April, 1998))
+            (Date(27, March, 1999))
+            (Date(16, March, 2000))
+            (Date(5, March, 2001))
+            (Date(23, February, 2002))
+            (Date(12, February, 2003))
+            (Date(1, February, 2004))
+            (Date(21, January, 2005))
+            (Date(10, January, 2006))
+            (Date(31, December, 2006))
+            (Date(20, December, 2007))
+            (Date(8, December, 2008))
+            (Date(27, November, 2009))
+            (Date(16, November, 2010))
+            (Date(6, November, 2011))
+            (Date(26, October, 2012))
+            (Date(15, October, 2013))
+            (Date(5, October, 2014))
+            (Date(23, September, 2015))
+            (Date(11, September, 2016))
+            (Date(1, September, 2017))
+            (Date(21, August, 2018))
+            (Date(11, August, 2019))
+            (Date(31, July, 2020))
+            (Date(20, July, 2021))
+            (Date(18, July, 2022)); 
+
+        // Eid al Fitr dates taken from:
+        // https://en.wikipedia.org/wiki/Eid_al-Fitr#In_the_Gregorian_calendar 
+        static std::vector<Date> EidUlFitr = boost::assign::list_of(Date(7, April, 1998))
+            (Date(16, Dec, 2001))
+            (Date(5, Dec, 2002))
+            (Date(25, Nov, 2003))
+            (Date(14, Nov, 2004))
+            (Date(3, Nov, 2005))
+            (Date(23, Oct, 2006))
+            (Date(13, Oct, 2007))
+            (Date(1, Oct, 2008))
+            (Date(20, Sep, 2009))
+            (Date(10, Sep, 2010))
+            (Date(30, Aug, 2011))
+            (Date(19, Aug, 2012))
+            (Date(8, Aug, 2013))
+            (Date(28, Jul, 2014))
+            (Date(17, Jul, 2015))
+            (Date(6, Jul, 2016))
+            (Date(25, Jun, 2017))
+            (Date(15, Jun, 2018))
+            (Date(4, Jun, 2019))
+            (Date(24, May, 2020))
+            (Date(13, May, 2021))
+            (Date(2, May, 2022))
+            (Date(21, Apr, 2023))
+            (Date(10, Apr, 2024))
+            (Date(30, Mar, 2025))
+            (Date(20, Mar, 2026))
+            (Date(9, Mar, 2027))
+            (Date(26, Feb, 2028))
+            (Date(14, Feb, 2029)); 
+
+        // In 2015 and 2014, the Eid holidays of the Tadawul Exchange have been from Eid-1 to Eid+4
+        // Sometimes, slightly longer holidays are observed 
+        // But conservatively, we take Eid-1 to Eid+4 as the holiday
+
+        // Eid Date    Holiday     Offset    Remarks
+        // 2015-09-23    22-27     -1,+4     later extended to 22-28 or -1+5
+        // 2015-07-17    18-21     -1,+4
+        // 2014-10-05    03-11     -1,+4     because of weekend 03-11 is same as 04-09 
+        // 2014-07-28    25-03     -1,+4     because of weekend 25-03 is same as 27-01
+        // 2013-10-15    11-19     -2,+4     because of weekend 11-19 is same as 13-19 
+        // 2013-08-08    06-12     -2,+4 
+        // 2012-10-26    25-03     -1,+5     because of weekend 25-03 is same as 25-31 
+        // 2012-08-19    16-24     -1,+4     because of weekend 16-24 is same as 18-23
+
+        // http://www.tadawul.com.sa/wps/portal/!ut/p/c1/04_SB8K8xLLM9MSSzPy8xBz9CP0os3g_A-ewIE8TIwN_D38LA09vV7NQP8cQQ3dnA6B8JJK8e0CYqYGniU-wUXCAl7GBpxEB3cGpefp-Hvm5qfqR-lHmuFUa64foRzoBFUXiVVSQG1Hul5atCAD59Xfd/dl2/d1/L3dJMjIyMnchL0lGaEFDRW9BREFMS0FBd0VLZ0FNQktvQURBeHFBQXdBNmdBTURCb0FEQUNhQUF3QVdnQU1BQSEhL1lJNXcvN19OMENWUkk0MjBPSE84MElLRTZVTkFUMUdDMw!!/?type=-1&companySymbol=&period=5+years&PRESS_REL_ACTION=PRESS_REL_SEARCH&startDate=&startDate=2015%2F11%2F23&startDate_Month=10&endDate=&endDate=2015%2F11%2F23&endDate_Month=10&orderBy=date&keyword=holiday&x=22&y=8
+
+        bool isEidAlAdha = false;
+        for(std::vector<QuantLib::Date>::iterator p = EidAlAdha.begin(); p!=EidAlAdha.end(); ++p){
+            if(p->year() == y && date >= *p -1 && date <= *p + 4){
+                isEidAlAdha = true;
+                break;
+            }
+        }
+
+        bool isEidUlFitr = false;
+        for(std::vector<QuantLib::Date>::iterator p = EidUlFitr.begin(); p!=EidUlFitr.end(); ++p){
+            if(p->year() == y && date >= *p -1 && date <= *p + 4){
+                isEidUlFitr = true;
+                break;
+            }
+        }
+
+        bool isTrueWeekend = (date < Date(29, June, 2013)) ?
+            (w == Thursday || w == Friday) :
+            (w == Friday || w == Saturday);
+        // The Saudi weekend was changed from 29th June 2013
+        // http://www.tadawul.com.sa/wps/portal/!ut/p/c1/04_SB8K8xLLM9MSSzPy8xBz9CP0os3g_A-ewIE8TIwN_D38LA09vV7NQP8cQQ3dnA6B8JJK8e0CYqYGniU-wUXCAl7GBpxEB3cGpefp-Hvm5qfqR-lHmuFUa64foRzoDFUXiVVSQG1Hul5atCAAXcU58/dl2/d1/L2dJQSEvUUt3QS9ZQnB3LzZfTjBDVlJJNDIwT0hPODBJS0U2VU5BVDFHQzA!/?x=1&PRESS_REL_NO=3421
+
+        if (isTrueWeekend
+            || isEidAlAdha
+            || isEidUlFitr
             // National Day
             || (d == 23 && m == September)
-            // Eid Al-Adha
-            || (d >= 1 && d <= 6 && m == February && y==2004)
-            || (d >= 21 && d <= 25 && m == January && y==2005)
-            || (d >= 26 && m == November && y==2009)
-            || (d <= 4 && m == December && y==2009)
-            || (d >= 11 && d <= 19 && m == November && y==2010)
-            // Eid Al-Fitr
-            || (d >= 25 && d <= 29 && m == November && y==2004)
-            || (d >= 14 && d <= 18 && m == November && y==2005)
-            || (d >= 25 && m == August && y==2011)
-            || (d <= 2 && m == September && y==2011)
             // other one-shot holidays
             || (d == 26 && m == February && y==2011)
             || (d == 19 && m == March && y==2011)


### PR DESCRIPTION
The Saudi Arabian (Tadawul Exchange) calendar in QuantLib has not been updated since 2011 and does not reflect the change in the weekend (from Thu/Fri to Fri/Sat) that was made in 2013. Also, the data on the Eid holidays (which varies from year to year) are available sparsely for 2004-2011 only.

This patch is an attempt to improve the QuantLib implementation of the Saudi calendar. It implements the change in the weekend and also populates the Eid dates for about 30 years using public sources. This is still imperfect as it assumes that the Eid holidays are for a fixed number of days around the actual Eid dates, though in practice the duration of the holidays also varies. Also one-off holidays are ignored.

The Saudi Arabian (Tadawul Exchange) calendar in QuantLib has not been updated since 2011 and does not reflect the change in the weekend (from Thu/Fri to Fri/Sat) that was made in 2013. Also, the data on the Eid holidays (which varies from year to year) are available sparsely for 2004-2011 only.

This pull request is an attempt to improve the QuantLib implementation of the Saudi calendar. It implements the change in the weekend and also populates the Eid dates for about 30 years using public sources. This is still imperfect as it assumes that the Eid holidays are for a fixed number of days around the actual Eid dates, though in practice the duration of the holidays also varies. Also one-off holidays are ignored.

The Saudi calendar is not of much financial importance, but I find it very useful for educational purposes. I use it as a reminder to my students that even the most trivial assumptions (like weekend is Sat/Sun) should not be taken for granted. Hence an updated Saudi calendar even if imperfect would be useful.