### PR TITLE
Remove hardcoded dependence from the FRA sample.

### DIFF
--- a/QuantLib/Examples/FRA/Makefile.am
+++ b/QuantLib/Examples/FRA/Makefile.am
@@ -8,7 +8,7 @@ else
 noinst_PROGRAMS = FRA
 endif
 FRA_SOURCES = FRA.cpp
-FRA_LDADD = ../../ql/libQuantLib.la -lboost_thread ${BOOST_THREAD_LIB}
+FRA_LDADD = ../../ql/libQuantLib.la ${BOOST_THREAD_LIB}
 
 EXTRA_DIST = \
     FRA.dev \


### PR DESCRIPTION
This removes a hardcoded ` -lboost_thread` flag -- which is superfluous due to the already-present `${BOOST_THREAD_LIB}` and breaks builds where the binary file for the Boost.Thread library is named differently.

Context: It seems it's been introduced w/ the thread-safe observer: https://github.com/lballabio/quantlib/blame/master/QuantLib/Examples/FRA/Makefile.am#L11