### PR TITLE
Fix compilation error in QuantLib-Python on OSX 10.11.1 Yosemite.

### DIFF
--- a/QuantLib-SWIG/SWIG/linearalgebra.i
+++ b/QuantLib-SWIG/SWIG/linearalgebra.i
@@ -1009,7 +1009,8 @@ class DefaultLexicographicalView {
                 for (Size i=0; i<self->xSize(); i++) {
                     if (i != 0)
                         s << ",";
-                    s << (*self)[i][j];
+                    Array::value_type value = (*self)[i][j];
+                    s << value;
                 }
             }
             s << "\n";


### PR DESCRIPTION
This patch fixes the compile error reported as #307 for SWIG/Python under clang and OSX 10.11.1. The error occurs when the <valarray> header has been included, which clobbers the << operator. I now no longer need to fiddle with the compiler's environment as recommended on the web site at http://quantlib.org/install/macosx.shtml -- with boost locations correctly set up, I can compile both the library and QuantLib-Python using stock clang. (Other SWIG modules still need help to compile on OSX though.)